### PR TITLE
Type safe drawer

### DIFF
--- a/Examples/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/Examples/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run \'pod install\' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		6AF3F1B07CA3D96A8145F9B2 /* [CP] Copy Pods Resources */ = {

--- a/Examples/SampleApp/SampleApp/CustomHeader.swift
+++ b/Examples/SampleApp/SampleApp/CustomHeader.swift
@@ -12,20 +12,17 @@ public class CustomHeaderDrawer: HeaderFooterDrawer {
     public static let nib = UINib(nibName: String(describing: CustomHeaderFooterView.self), bundle: nil)
     static public var type = HeaderFooterType.nib(CustomHeaderDrawer.nib, CustomHeaderFooterView.self)
     
-    static public func draw(_ view: UITableViewHeaderFooterView, with item: Any) {
-        let item = item as! CustomHeaderItem
-        let view = view as! CustomHeaderFooterView
+    static public func draw(_ view: CustomHeaderFooterView, with item: CustomHeaderItem) {
         view.label.text = item.title
     }
 }
 
 
 public class CustomHeaderItem: HeaderFooter {
-    
+    public static var drawer = HeaderFooterDrawerOf(CustomHeaderDrawer.self)
+
     public var title: String?
     public var height: Height? = .dynamic(44.0)
-    
-    public var drawer: HeaderFooterDrawer.Type = CustomHeaderDrawer.self
     
     public init() { }
     

--- a/Examples/SampleApp/SampleApp/CustomHeader.swift
+++ b/Examples/SampleApp/SampleApp/CustomHeader.swift
@@ -19,7 +19,7 @@ public class CustomHeaderDrawer: HeaderFooterDrawer {
 
 
 public class CustomHeaderItem: HeaderFooter {
-    public static var drawer = HeaderFooterDrawerOf(CustomHeaderDrawer.self)
+    public static var drawer = AnyHeaderFooterDrawer(CustomHeaderDrawer.self)
 
     public var title: String?
     public var height: Height? = .dynamic(44.0)

--- a/Examples/SampleApp/SampleApp/CustomItem.swift
+++ b/Examples/SampleApp/SampleApp/CustomItem.swift
@@ -4,10 +4,9 @@ import TableViewKit
 
 public class CustomDrawer: CellDrawer {
     
-    static public var type = CellType.class(UITableViewCell.self)
+    public static var type = CellType.class(UITableViewCell.self)
     
-    static public func draw(_ cell: UITableViewCell, with item: Any) {
-        let item = item as! CustomItem
+    public static func draw(_ cell: UITableViewCell, with item: CustomItem) {
         cell.accessoryType = item.accessoryType
         cell.accessoryView = item.accessoryView
         cell.textLabel?.text = item.title
@@ -16,7 +15,8 @@ public class CustomDrawer: CellDrawer {
 
 
 public class CustomItem: Selectable, Item {
-    
+    public static var drawer = CellDrawerOf(CustomDrawer.self)
+
     public var title: String?
     
     public var onSelection: (Selectable) -> () = { _ in }
@@ -26,7 +26,6 @@ public class CustomItem: Selectable, Item {
     public var accessoryView: UIView?
     public var cellHeight: CGFloat? = UITableViewAutomaticDimension
     
-    public var drawer: CellDrawer.Type = CustomDrawer.self
     
     public init() { }
     

--- a/Examples/SampleApp/SampleApp/CustomItem.swift
+++ b/Examples/SampleApp/SampleApp/CustomItem.swift
@@ -15,7 +15,7 @@ public class CustomDrawer: CellDrawer {
 
 
 public class CustomItem: Selectable, Item {
-    public static var drawer = CellDrawerOf(CustomDrawer.self)
+    public static var drawer = AnyCellDrawer(CustomDrawer.self)
 
     public var title: String?
     

--- a/Examples/SampleApp/SampleApp/SelectionViewController.swift
+++ b/Examples/SampleApp/SampleApp/SelectionViewController.swift
@@ -21,7 +21,10 @@ public enum SelectionType {
     case Single, Multiple
 }
 
-public class SelectionItem: SelectionItemProtocol {    
+public class SelectionItem: SelectionItemProtocol {
+    public static var drawer = CellDrawerOf(CustomDrawer.self)
+
+    
     public var title: String?
     
     public var value: Any
@@ -33,8 +36,6 @@ public class SelectionItem: SelectionItemProtocol {
     public var accessoryView: UIView?
     public var cellHeight: CGFloat? = UITableViewAutomaticDimension
     
-    public var drawer: CellDrawer.Type = CustomDrawer.self
-
     
     public required init(title: String, value: Any, selected: Bool = false) {
         self.value = value

--- a/Examples/SampleApp/SampleApp/SelectionViewController.swift
+++ b/Examples/SampleApp/SampleApp/SelectionViewController.swift
@@ -22,7 +22,7 @@ public enum SelectionType {
 }
 
 public class SelectionItem: SelectionItemProtocol {
-    public static var drawer = CellDrawerOf(CustomDrawer.self)
+    public static var drawer = AnyCellDrawer(CustomDrawer.self)
 
     
     public var title: String?

--- a/Examples/SampleApp/SampleApp/TextFieldItem.swift
+++ b/Examples/SampleApp/SampleApp/TextFieldItem.swift
@@ -52,19 +52,15 @@ public class TextFieldDrawer: CellDrawer {
     public static let nib = UINib(nibName: String(describing: TextFieldCell.self), bundle: nil)
     public static let type = CellType.nib(TextFieldDrawer.nib, TextFieldCell.self)
     
-    public static func draw(_ cell: UITableViewCell, with item: Any) {
-        
-        let textCell = cell as! TextFieldCell
-        let textItem = item as! TextFieldItem
-        
-        textCell.textField.placeholder = textItem.placeHolder
-        textCell.textField.text = textItem.value
+    public static func draw(_ cell: TextFieldCell, with item: TextFieldItem) {
+        cell.textField.placeholder = item.placeHolder
+        cell.textField.text = item.value
     }
 }
 
 public class TextFieldItem: UIResponder, Item, ContentValidatable, Validationable {
-        
-    public var drawer: CellDrawer.Type = TextFieldDrawer.self
+    
+    public static var drawer = CellDrawerOf(TextFieldDrawer.self)
     
     public lazy var validation: Validation<String?> = {
         return Validation<String?>(forInput: self, withIdentifier: self)

--- a/Examples/SampleApp/SampleApp/TextFieldItem.swift
+++ b/Examples/SampleApp/SampleApp/TextFieldItem.swift
@@ -60,7 +60,7 @@ public class TextFieldDrawer: CellDrawer {
 
 public class TextFieldItem: UIResponder, Item, ContentValidatable, Validationable {
     
-    public static var drawer = CellDrawerOf(TextFieldDrawer.self)
+    public static var drawer = AnyCellDrawer(TextFieldDrawer.self)
     
     public lazy var validation: Validation<String?> = {
         return Validation<String?>(forInput: self, withIdentifier: self)

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterCell.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterCell.swift
@@ -3,16 +3,11 @@ import TableViewKit
 
 class HelpCenterDrawer: CellDrawer {
     
-    static var type: CellType = CellType.nib(UINib(nibName: String(describing: HelpCenterCell.self), bundle: Bundle.main), HelpCenterCell.self)
+    static var type = CellType.nib(UINib(nibName: String(describing: HelpCenterCell.self), bundle: Bundle.main), HelpCenterCell.self)
     
-    static func draw(_ cell: UITableViewCell, with item: Any) {
-        
-        guard let helpCenterCell = cell as? HelpCenterCell,
-              let helpCenterItem = item as? HelpCenterItem
-        else { return }
-        
-        helpCenterCell.selectionStyle = .none
-        helpCenterCell.titleLabel.text = helpCenterItem.title
+    static func draw(_ cell: HelpCenterCell, with item: HelpCenterItem) {
+        cell.selectionStyle = .none
+        cell.titleLabel.text = item.title
     }
 }
 

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterItem.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterItem.swift
@@ -2,7 +2,7 @@ import Foundation
 import TableViewKit
 
 class HelpCenterItem: Item {
-    static var drawer = CellDrawerOf(HelpCenterDrawer.self)
+    static var drawer = AnyCellDrawer(HelpCenterDrawer.self)
 
     var height: Height? = .dynamic(44.0)
     

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterItem.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterItem.swift
@@ -2,8 +2,8 @@ import Foundation
 import TableViewKit
 
 class HelpCenterItem: Item {
-    
-    var drawer: CellDrawer.Type = HelpCenterDrawer.self
+    static var drawer = CellDrawerOf(HelpCenterDrawer.self)
+
     var height: Height? = .dynamic(44.0)
     
     var title: String?

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutCell.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutCell.swift
@@ -5,10 +5,7 @@ class MoreAboutDrawer: CellDrawer {
     
     static open var type = CellType.class(UITableViewCell.self)
     
-    static open func draw(_ cell: UITableViewCell, with item: Any) {
-        
-        let item = item as! MoreAboutItem
-        
+    static open func draw(_ cell: UITableViewCell, with item: MoreAboutItem) {
         cell.accessoryType = .disclosureIndicator
         cell.textLabel?.text = item.title
     }

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutItem.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutItem.swift
@@ -24,7 +24,7 @@ enum MoreAboutItemType {
 }
 
 class MoreAboutItem: Item, Selectable, Editable {
-    public static var drawer = CellDrawerOf(MoreAboutDrawer.self)
+    public static var drawer = AnyCellDrawer(MoreAboutDrawer.self)
 
     var type: MoreAboutItemType
     var title: String?

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutItem.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutItem.swift
@@ -24,11 +24,11 @@ enum MoreAboutItemType {
 }
 
 class MoreAboutItem: Item, Selectable, Editable {
+    public static var drawer = CellDrawerOf(MoreAboutDrawer.self)
 
     var type: MoreAboutItemType
     var title: String?
     
-    var drawer: CellDrawer.Type = MoreAboutDrawer.self
     var onSelection: (Selectable) -> () = { _ in }
     
     var actions: [UITableViewRowAction]?

--- a/README.md
+++ b/README.md
@@ -35,16 +35,16 @@ Create an `Item` with a `UITableViewCell` and `CellDrawer`. An item may have a m
 class YourDrawer: CellDrawer {
 
     // The type could be a custom UITableViewCell class, with or without a Nib
-    static public var type = CellType.class(UITableViewCell.self)
+    static var type = CellType.class(YourCustomCell.self)
 
-    static public func draw(_ cell: UITableViewCell, with item: Any) {
+    static func draw(_ cell: YourCustomCell, with item: YourItem) {
         // Draw by setting properties of your cell from the item
     }
 }
 
 class YourItem: Item {
 
-    public var drawer: CellDrawer.Type = YourDrawer.self
+    var drawer = AnyCellDrawer(YourDrawer.self)
 
     // Your properties and methods
 

--- a/TableViewKit.xcodeproj/project.pbxproj
+++ b/TableViewKit.xcodeproj/project.pbxproj
@@ -113,11 +113,11 @@
 				CCFD05CB1D95BD3C0063A002 /* Stateful.swift */,
 				CCCAC1251D7D9EE00001FC1D /* HeaderFooter.swift */,
 				CCEF387F1D8D5A7A00F5893F /* HeaderFooterDrawer.swift */,
+				CCBE458A1D72F79C00414A64 /* CellDrawer.swift */,
 				CCBE458C1D72F79C00414A64 /* Item.swift */,
 				CC97D76C1D741DC4009CDF9D /* Selectable.swift */,
 				25B0B7531DC74F6C00591467 /* Editable.swift */,
 				25837C771D87F819001EF4B8 /* ItemCompatible.swift */,
-				CCBE458A1D72F79C00414A64 /* CellDrawer.swift */,
 				CC0DE2C71DE33B9C00E2EDE5 /* AnyEquatable.swift */,
 			);
 			name = Protocols;

--- a/TableViewKit/Extensions/UITableView+Register.swift
+++ b/TableViewKit/Extensions/UITableView+Register.swift
@@ -5,7 +5,7 @@ extension UITableView {
     /// Register a cell type for reuse
     ///
     /// - parameter type: The type of cell that must be registered
-    public func register(_ type: CellType) {
+    public func register(_ type: NibClassType<UITableViewCell>) {
         switch type {
         case .class(let cellClass):
             self.register(cellClass, forCellReuseIdentifier: type.reusableIdentifier)
@@ -17,7 +17,7 @@ extension UITableView {
     /// Register a header/footer type for reuse
     ///
     /// - parameter type: The type of header/footer that must be registered
-    public func register(_ type: HeaderFooterType) {
+    public func register(_ type: NibClassType<UITableViewHeaderFooterView>) {
         switch type {
         case .class(let cellClass):
             self.register(cellClass, forHeaderFooterViewReuseIdentifier: type.reusableIdentifier)

--- a/TableViewKit/NibClassType.swift
+++ b/TableViewKit/NibClassType.swift
@@ -23,3 +23,25 @@ public enum NibClassType<T> {
         }
     }
 }
+
+extension NibClassType where T: UITableViewCell {
+    var cellType: NibClassType<UITableViewCell> {
+        switch self {
+        case .class(let type):
+            return NibClassType<UITableViewCell>.class(type)
+        case .nib(let nib, let type):
+            return NibClassType<UITableViewCell>.nib(nib, type)
+        }
+    }
+}
+
+extension NibClassType where T: UITableViewHeaderFooterView {
+    var headerFooterType: NibClassType<UITableViewHeaderFooterView> {
+        switch self {
+        case .class(let type):
+            return NibClassType<UITableViewHeaderFooterView>.class(type)
+        case .nib(let nib, let type):
+            return NibClassType<UITableViewHeaderFooterView>.nib(nib, type)
+        }
+    }
+}

--- a/TableViewKit/Protocols/CellDrawer.swift
+++ b/TableViewKit/Protocols/CellDrawer.swift
@@ -2,13 +2,15 @@ import Foundation
 import UIKit
 
 /// The type of a cell (nib, class)
-public typealias CellType = NibClassType<UITableViewCell>
+public typealias CellType<Cell: UITableViewCell> = NibClassType<Cell>
 
 /// A type that can draw a cell
 public protocol CellDrawer {
+    associatedtype Cell: UITableViewCell
+    associatedtype GenericItem
 
     /// Define the `type` of the cell
-    static var type: CellType { get }
+    static var type: CellType<Cell> { get }
     
     /// Returns the cell from the `manager`
     ///
@@ -17,28 +19,57 @@ public protocol CellDrawer {
     /// - parameter indexPath:    Where the cell is located
     ///
     /// - returns: The the cell
-    static func cell(in manager: TableViewManager, with item: Item, for indexPath: IndexPath) -> UITableViewCell
+    static func cell(in manager: TableViewManager, with item: GenericItem, for indexPath: IndexPath) -> Cell
     
     /// Draw the `cell` using the `item`
     ///
     /// - parameter cell: The `cell` that must be drawn
     /// - parameter item: The cell `item` that generated the drawer
-    static func draw(_ cell: UITableViewCell, with item: Any)
+    static func draw(_ cell: Cell, with item: GenericItem)
 
 }
 
 public extension CellDrawer {
     
     /// Returns a dequeued cell and set the item property if the cell conforms to ItemCompatible
-    static func cell(in manager: TableViewManager, with item: Item, for indexPath: IndexPath) -> UITableViewCell {
+    static func cell(in manager: TableViewManager, with item: GenericItem, for indexPath: IndexPath) -> Cell {
         
         let cell = manager.tableView.dequeueReusableCell(withIdentifier: self.type.reusableIdentifier, for: indexPath)
         cell.selectionStyle = item is Selectable ? .default : .none
         
         if let cell = cell as? ItemCompatible {
-            cell.item = item
+            cell.item = item as? Item
         }
         
-        return cell
+        return cell as! Cell
     }
+}
+
+public struct CellDrawerOf {
+    
+    let _cell: (TableViewManager, Item, IndexPath) -> UITableViewCell
+    let _draw: (UITableViewCell, Item) -> ()
+    
+    public init<Drawer: CellDrawer, GenericItem, Cell: UITableViewCell>(_ drawer: Drawer.Type) where Drawer.GenericItem == GenericItem, Drawer.Cell == Cell {
+        switch drawer.type {
+        case .class(let type):
+            self.type = NibClassType<UITableViewCell>.class(type)
+        case .nib(let nib, let type):
+            self.type = NibClassType<UITableViewCell>.nib(nib, type)
+        }
+        self._cell = { manager, item, indexPath in drawer.cell(in: manager, with: item as! GenericItem, for: indexPath) }
+        self._draw = { cell, item in drawer.draw(cell as! Cell, with: item as! GenericItem) }
+    }
+    
+    public let type: CellType<UITableViewCell>
+    
+    public func cell(in manager: TableViewManager, with item: Item, for indexPath: IndexPath) -> UITableViewCell {
+        return _cell(manager, item, indexPath)
+    }
+    
+    
+    public func draw(_ cell: UITableViewCell, with item: Item) {
+        _draw(cell, item)
+    }
+    
 }

--- a/TableViewKit/Protocols/CellDrawer.swift
+++ b/TableViewKit/Protocols/CellDrawer.swift
@@ -45,31 +45,23 @@ public extension CellDrawer {
     }
 }
 
-public struct CellDrawerOf {
-    
-    let _cell: (TableViewManager, Item, IndexPath) -> UITableViewCell
-    let _draw: (UITableViewCell, Item) -> ()
+public struct AnyCellDrawer {
+    let type: CellType<UITableViewCell>
+    let cell: (TableViewManager, Item, IndexPath) -> UITableViewCell
+    let draw: (UITableViewCell, Item) -> ()
     
     public init<Drawer: CellDrawer, GenericItem, Cell: UITableViewCell>(_ drawer: Drawer.Type) where Drawer.GenericItem == GenericItem, Drawer.Cell == Cell {
-        switch drawer.type {
-        case .class(let type):
-            self.type = NibClassType<UITableViewCell>.class(type)
-        case .nib(let nib, let type):
-            self.type = NibClassType<UITableViewCell>.nib(nib, type)
-        }
-        self._cell = { manager, item, indexPath in drawer.cell(in: manager, with: item as! GenericItem, for: indexPath) }
-        self._draw = { cell, item in drawer.draw(cell as! Cell, with: item as! GenericItem) }
+        self.type = drawer.type.cellType
+        self.cell = { manager, item, indexPath in drawer.cell(in: manager, with: item as! GenericItem, for: indexPath) }
+        self.draw = { cell, item in drawer.draw(cell as! Cell, with: item as! GenericItem) }
     }
     
-    public let type: CellType<UITableViewCell>
-    
-    public func cell(in manager: TableViewManager, with item: Item, for indexPath: IndexPath) -> UITableViewCell {
-        return _cell(manager, item, indexPath)
+    func cell(in manager: TableViewManager, with item: Item, for indexPath: IndexPath) -> UITableViewCell {
+        return cell(manager, item, indexPath)
     }
     
-    
-    public func draw(_ cell: UITableViewCell, with item: Item) {
-        _draw(cell, item)
+    func draw(_ cell: UITableViewCell, with item: Item) {
+        draw(cell, item)
     }
     
 }

--- a/TableViewKit/Protocols/CellDrawer.swift
+++ b/TableViewKit/Protocols/CellDrawer.swift
@@ -45,22 +45,24 @@ public extension CellDrawer {
     }
 }
 
+/// A type-erased wrapper over any cell drawer
 public struct AnyCellDrawer {
     let type: CellType<UITableViewCell>
     let cell: (TableViewManager, Item, IndexPath) -> UITableViewCell
     let draw: (UITableViewCell, Item) -> ()
-    
+
+	/// Creates a type-erased drawer that wraps the given cell drawer
     public init<Drawer: CellDrawer, GenericItem, Cell: UITableViewCell>(_ drawer: Drawer.Type) where Drawer.GenericItem == GenericItem, Drawer.Cell == Cell {
         self.type = drawer.type.cellType
         self.cell = { manager, item, indexPath in drawer.cell(in: manager, with: item as! GenericItem, for: indexPath) }
         self.draw = { cell, item in drawer.draw(cell as! Cell, with: item as! GenericItem) }
     }
     
-    public func cell(in manager: TableViewManager, with item: Item, for indexPath: IndexPath) -> UITableViewCell {
+	func cell(in manager: TableViewManager, with item: Item, for indexPath: IndexPath) -> UITableViewCell {
         return cell(manager, item, indexPath)
     }
     
-    public func draw(_ cell: UITableViewCell, with item: Item) {
+	func draw(_ cell: UITableViewCell, with item: Item) {
         draw(cell, item)
     }
     

--- a/TableViewKit/Protocols/HeaderFooter.swift
+++ b/TableViewKit/Protocols/HeaderFooter.swift
@@ -20,7 +20,7 @@ public enum HeaderFooterView: ExpressibleByNilLiteral {
 public protocol HeaderFooter: class {
 
     /// The `drawer` of the header/footer
-    var drawer: HeaderFooterDrawer.Type { get }
+    static var drawer: HeaderFooterDrawerOf { get }
 
     /// The `height` of the header/footer
     var height: Height? { get }

--- a/TableViewKit/Protocols/HeaderFooter.swift
+++ b/TableViewKit/Protocols/HeaderFooter.swift
@@ -20,7 +20,7 @@ public enum HeaderFooterView: ExpressibleByNilLiteral {
 public protocol HeaderFooter: class {
 
     /// The `drawer` of the header/footer
-    static var drawer: HeaderFooterDrawerOf { get }
+    static var drawer: AnyHeaderFooterDrawer { get }
 
     /// The `height` of the header/footer
     var height: Height? { get }

--- a/TableViewKit/Protocols/HeaderFooterDrawer.swift
+++ b/TableViewKit/Protocols/HeaderFooterDrawer.swift
@@ -37,31 +37,23 @@ public extension HeaderFooterDrawer {
     }
 }
 
-public struct HeaderFooterDrawerOf {
-    
-    let _view: (TableViewManager, HeaderFooter) -> UITableViewHeaderFooterView
-    let _draw: (UITableViewHeaderFooterView, HeaderFooter) -> ()
+public struct AnyHeaderFooterDrawer {
+    let type: HeaderFooterType<UITableViewHeaderFooterView>
+    let view: (TableViewManager, HeaderFooter) -> UITableViewHeaderFooterView
+    let draw: (UITableViewHeaderFooterView, HeaderFooter) -> ()
     
     public init<Drawer: HeaderFooterDrawer, GenericItem, View: UITableViewHeaderFooterView>(_ drawer: Drawer.Type) where Drawer.GenericItem == GenericItem, Drawer.View == View {
-        switch drawer.type {
-        case .class(let type):
-            self.type = NibClassType<UITableViewHeaderFooterView>.class(type)
-        case .nib(let nib, let type):
-            self.type = NibClassType<UITableViewHeaderFooterView>.nib(nib, type)
-        }
-        self._view = { manager, item in drawer.view(in: manager, with: item as! GenericItem) }
-        self._draw = { cell, item in drawer.draw(cell as! View, with: item as! GenericItem) }
+        self.type = drawer.type.headerFooterType
+        self.view = { manager, item in drawer.view(in: manager, with: item as! GenericItem) }
+        self.draw = { cell, item in drawer.draw(cell as! View, with: item as! GenericItem) }
     }
     
-    public let type: HeaderFooterType<UITableViewHeaderFooterView>
-    
-    public func view(in manager: TableViewManager, with item: HeaderFooter) -> UITableViewHeaderFooterView {
-        return _view(manager, item)
+    func view(in manager: TableViewManager, with item: HeaderFooter) -> UITableViewHeaderFooterView {
+        return view(manager, item)
     }
     
-    
-    public func draw(_ view: UITableViewHeaderFooterView, with item: HeaderFooter) {
-        _draw(view, item)
+    func draw(_ view: UITableViewHeaderFooterView, with item: HeaderFooter) {
+        draw(view, item)
     }
     
 }

--- a/TableViewKit/Protocols/HeaderFooterDrawer.swift
+++ b/TableViewKit/Protocols/HeaderFooterDrawer.swift
@@ -2,19 +2,22 @@ import Foundation
 import UIKit
 
 /// The type of a header/footer (nib, class)
-public typealias HeaderFooterType = NibClassType<UITableViewHeaderFooterView>
+public typealias HeaderFooterType<View: UITableViewHeaderFooterView> = NibClassType<View>
+
 
 /// A type that can draw either a header or a footer
 public protocol HeaderFooterDrawer {
-    
+    associatedtype View: UITableViewHeaderFooterView
+    associatedtype GenericItem
+
     /// Define the `type` of the header/footer
-    static var type: HeaderFooterType { get }
+    static var type: HeaderFooterType<View> { get }
     
     /// Draw the `view` using the `item`
     ///
     /// - parameter view: The header/footer `view` that must be drawn
     /// - parameter item: The header/footer `item` that generated the drawer
-    static func draw(_ view: UITableViewHeaderFooterView, with item: Any)
+    static func draw(_ view: View, with item: GenericItem)
     
     
     /// Returns the header/footer view from the `manager`
@@ -23,13 +26,42 @@ public protocol HeaderFooterDrawer {
     /// - parameter item:    The header/footer `item`
     ///
     /// - returns: The header/footer view
-    static func view(in manager: TableViewManager, with item: HeaderFooter) -> UITableViewHeaderFooterView
+    static func view(in manager: TableViewManager, with item: GenericItem) -> View
 }
 
 public extension HeaderFooterDrawer {
     
     /// Returns a dequeued header/footer
-    static func view(in manager: TableViewManager, with item: HeaderFooter) -> UITableViewHeaderFooterView {
-        return manager.tableView.dequeueReusableHeaderFooterView(withIdentifier: self.type.reusableIdentifier)!
+    static func view(in manager: TableViewManager, with item: GenericItem) -> View {
+        return manager.tableView.dequeueReusableHeaderFooterView(withIdentifier: self.type.reusableIdentifier) as! View
     }
+}
+
+public struct HeaderFooterDrawerOf {
+    
+    let _view: (TableViewManager, HeaderFooter) -> UITableViewHeaderFooterView
+    let _draw: (UITableViewHeaderFooterView, HeaderFooter) -> ()
+    
+    public init<Drawer: HeaderFooterDrawer, GenericItem, View: UITableViewHeaderFooterView>(_ drawer: Drawer.Type) where Drawer.GenericItem == GenericItem, Drawer.View == View {
+        switch drawer.type {
+        case .class(let type):
+            self.type = NibClassType<UITableViewHeaderFooterView>.class(type)
+        case .nib(let nib, let type):
+            self.type = NibClassType<UITableViewHeaderFooterView>.nib(nib, type)
+        }
+        self._view = { manager, item in drawer.view(in: manager, with: item as! GenericItem) }
+        self._draw = { cell, item in drawer.draw(cell as! View, with: item as! GenericItem) }
+    }
+    
+    public let type: HeaderFooterType<UITableViewHeaderFooterView>
+    
+    public func view(in manager: TableViewManager, with item: HeaderFooter) -> UITableViewHeaderFooterView {
+        return _view(manager, item)
+    }
+    
+    
+    public func draw(_ view: UITableViewHeaderFooterView, with item: HeaderFooter) {
+        _draw(view, item)
+    }
+    
 }

--- a/TableViewKit/Protocols/HeaderFooterDrawer.swift
+++ b/TableViewKit/Protocols/HeaderFooterDrawer.swift
@@ -37,11 +37,13 @@ public extension HeaderFooterDrawer {
     }
 }
 
+/// A type-erased wrapper over any header or footer drawer
 public struct AnyHeaderFooterDrawer {
     let type: HeaderFooterType<UITableViewHeaderFooterView>
     let view: (TableViewManager, HeaderFooter) -> UITableViewHeaderFooterView
     let draw: (UITableViewHeaderFooterView, HeaderFooter) -> ()
-    
+
+	/// Creates a type-erased drawer that wraps the given header or footer drawer
     public init<Drawer: HeaderFooterDrawer, GenericItem, View: UITableViewHeaderFooterView>(_ drawer: Drawer.Type) where Drawer.GenericItem == GenericItem, Drawer.View == View {
         self.type = drawer.type.headerFooterType
         self.view = { manager, item in drawer.view(in: manager, with: item as! GenericItem) }

--- a/TableViewKit/Protocols/Item.swift
+++ b/TableViewKit/Protocols/Item.swift
@@ -6,7 +6,7 @@ import Foundation
 public protocol Item: class, AnyEquatable {
     
     /// The `drawer` of the item
-    static var drawer: CellDrawerOf { get }
+    static var drawer: AnyCellDrawer { get }
     
     /// The `height` of the item
     var height: Height? { get }

--- a/TableViewKit/Protocols/Item.swift
+++ b/TableViewKit/Protocols/Item.swift
@@ -6,7 +6,7 @@ import Foundation
 public protocol Item: class, AnyEquatable {
     
     /// The `drawer` of the item
-    var drawer: CellDrawer.Type { get }
+    static var drawer: CellDrawerOf { get }
     
     /// The `height` of the item
     var height: Height? { get }

--- a/TableViewKit/Section.swift
+++ b/TableViewKit/Section.swift
@@ -41,13 +41,13 @@ extension Section {
     /// - parameter manager: A manager where the section may have been added
     internal func register(in manager: TableViewManager) {
         if case .view(let header) = header {
-            manager.tableView.register(header.drawer.type)
+            manager.tableView.register(type(of: header).drawer.type)
         }
         if case .view(let footer) = footer {
-            manager.tableView.register(footer.drawer.type)
+            manager.tableView.register(type(of: footer).drawer.type)
         }
         items.forEach {
-            manager.tableView.register($0.drawer.type)
+            manager.tableView.register(type(of: $0).drawer.type)
         }
     }
 

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -86,7 +86,7 @@ extension TableViewManager {
     fileprivate func view(for key: (Section) -> HeaderFooterView, inSection section: Int) -> UIView? {
         guard case .view(let item) = key(sections[section]) else { return nil }
         
-        let drawer = item.drawer
+        let drawer = type(of: item).drawer
         let view = drawer.view(in: self, with: item)
         drawer.draw(view, with: item)
         
@@ -150,7 +150,7 @@ extension TableViewManager: UITableViewDataSource {
     /// Implementation of UITableViewDataSource
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let currentItem = item(at: indexPath)
-        let drawer = currentItem.drawer
+        let drawer = type(of: currentItem).drawer
         
         let cell = drawer.cell(in: self, with: currentItem, for: indexPath)
         drawer.draw(cell, with: currentItem)

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -36,7 +36,7 @@ class TestDrawer: CellDrawer {
 }
 
 class TestItem: Item {
-    static internal var drawer = CellDrawerOf(TestDrawer.self)
+    static internal var drawer = AnyCellDrawer(TestDrawer.self)
 }
 
 class TestCell: UITableViewCell, ItemCompatible {

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -31,13 +31,12 @@ class HeaderFooterTitleSection: Section {
 }
 
 class TestDrawer: CellDrawer {
-    
     static internal var type = CellType.class(TestCell.self)
-    static internal func draw(_ cell: UITableViewCell, with item: Any) { }
+    static internal func draw(_ cell: TestCell, with item: Item) { }
 }
 
 class TestItem: Item {
-    internal var drawer: CellDrawer.Type = TestDrawer.self
+    static internal var drawer = CellDrawerOf(TestDrawer.self)
 }
 
 class TestCell: UITableViewCell, ItemCompatible {

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import TableViewKit
+@testable import TableViewKit
 import Nimble
 
 extension HeaderFooterView: Equatable {

--- a/TableViewKitTests/TableViewDelegateTests.swift
+++ b/TableViewKitTests/TableViewDelegateTests.swift
@@ -38,7 +38,7 @@ class ViewHeaderFooter: HeaderFooter {
     
     public var title: String?
     public var height: Height? = .dynamic(44.0)
-    static public var drawer = HeaderFooterDrawerOf(CustomHeaderDrawer.self)
+    static public var drawer = AnyHeaderFooterDrawer(CustomHeaderDrawer.self)
     
     public init() { }
     
@@ -61,20 +61,20 @@ class ViewHeaderFooterSection: Section {
 }
 
 class NoHeigthItem: Item {
-    static internal var drawer = CellDrawerOf(TestDrawer.self)
+    static internal var drawer = AnyCellDrawer(TestDrawer.self)
     
     internal var height: Height? = nil
 }
 
 class StaticHeigthItem: Item {
     static let testStaticHeightValue: CGFloat = 20.0
-    static internal var drawer = CellDrawerOf(TestDrawer.self)
+    static internal var drawer = AnyCellDrawer(TestDrawer.self)
     
     internal var height: Height? = .static(20.0)
 }
 
 class SelectableItem: Selectable, Item {
-    static internal var drawer = CellDrawerOf(TestDrawer.self)
+    static internal var drawer = AnyCellDrawer(TestDrawer.self)
 
     public var check: Int = 0    
     

--- a/TableViewKitTests/TableViewDelegateTests.swift
+++ b/TableViewKitTests/TableViewDelegateTests.swift
@@ -28,9 +28,7 @@ class CustomHeaderDrawer: HeaderFooterDrawer {
     
     static public var type = HeaderFooterType.class(CustomHeaderFooterView.self)
     
-    static public func draw(_ view: UITableViewHeaderFooterView, with item: Any) {
-        let item = item as! ViewHeaderFooter
-        let view = view as! CustomHeaderFooterView
+    static public func draw(_ view: CustomHeaderFooterView, with item: ViewHeaderFooter) {
         view.label.text = item.title
     }
 }
@@ -40,7 +38,7 @@ class ViewHeaderFooter: HeaderFooter {
     
     public var title: String?
     public var height: Height? = .dynamic(44.0)
-    public var drawer: HeaderFooterDrawer.Type = CustomHeaderDrawer.self
+    static public var drawer = HeaderFooterDrawerOf(CustomHeaderDrawer.self)
     
     public init() { }
     
@@ -63,23 +61,22 @@ class ViewHeaderFooterSection: Section {
 }
 
 class NoHeigthItem: Item {
-    internal var drawer: CellDrawer.Type = TestDrawer.self
+    static internal var drawer = CellDrawerOf(TestDrawer.self)
     
     internal var height: Height? = nil
 }
 
 class StaticHeigthItem: Item {
     static let testStaticHeightValue: CGFloat = 20.0
-    
-    internal var drawer: CellDrawer.Type = TestDrawer.self
+    static internal var drawer = CellDrawerOf(TestDrawer.self)
     
     internal var height: Height? = .static(20.0)
 }
 
 class SelectableItem: Selectable, Item {
-    public var check: Int = 0
-    
-    internal var drawer: CellDrawer.Type = TestDrawer.self
+    static internal var drawer = CellDrawerOf(TestDrawer.self)
+
+    public var check: Int = 0    
     
     public init() {}
     

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -14,7 +14,8 @@ class TestReloadDrawer: CellDrawer {
 }
 
 class TestReloadItem: Item {
-    internal var drawer: CellDrawer.Type = TestReloadDrawer.self
+    static internal var drawer = CellDrawerOf(TestReloadDrawer.self)
+
     internal var title: String?
 }
 
@@ -112,7 +113,7 @@ class TableViewKitTests: XCTestCase {
     func testRegisterNibCells() {
         
         let testBundle = Bundle(for: TableViewKitTests.self)
-        let cellType = CellType.nib(UINib(nibName: String(describing: TestRegisterNibCell.self), bundle: testBundle), TestRegisterNibCell.self)
+        let cellType = CellType<UITableViewCell>.nib(UINib(nibName: String(describing: TestRegisterNibCell.self), bundle: testBundle), TestRegisterNibCell.self)
         
         let tableView = UITableView()
         tableView.register(cellType)
@@ -125,7 +126,7 @@ class TableViewKitTests: XCTestCase {
     func testRegisterNibHeaderFooter() {
         
         let testBundle = Bundle(for: TableViewKitTests.self)
-        let headerFooterType = HeaderFooterType.nib(UINib(nibName: String(describing: TestRegisterHeaderFooterView.self), bundle: testBundle), TestRegisterHeaderFooterView.self)
+        let headerFooterType = CellType<UITableViewHeaderFooterView>.nib(UINib(nibName: String(describing: TestRegisterHeaderFooterView.self), bundle: testBundle), TestRegisterHeaderFooterView.self)
         
         let tableView = UITableView()
         tableView.register(headerFooterType)

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -14,7 +14,7 @@ class TestReloadDrawer: CellDrawer {
 }
 
 class TestReloadItem: Item {
-    static internal var drawer = CellDrawerOf(TestReloadDrawer.self)
+    static internal var drawer = AnyCellDrawer(TestReloadDrawer.self)
 
     internal var title: String?
 }


### PR DESCRIPTION
This PR finally improves the type safe system for our drawers: CellDrawer and HeaderFooterDrawer.
Both protocols are now generic.
Item and HeaderFooter protocols have been modified in order to conform to these changes.
Two new type erasure struct (AnyCellDrawer and AnyHeaderFooterDrawer) have been created in order to support this.

Documentation is still missing