### PR TITLE
Register cell after insert item in section

### DIFF
--- a/TableViewKit.podspec
+++ b/TableViewKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = "TableViewKit"
-  s.version                 = "0.9.5"
+  s.version                 = "0.9.6"
   s.summary                 = "Empowering UITableView with painless multi-type cell support and build-in automatic state transition animations"
   s.homepage                = "http://github.com/odigeoteam/TableViewKit/"
   s.license                 = "MIT"

--- a/TableViewKit/Section.swift
+++ b/TableViewKit/Section.swift
@@ -86,7 +86,10 @@ extension Section {
         
         switch changes {
         case .inserts(let array):
-            let indexPaths = array.map { IndexPath(item: $0, section: sectionIndex) }
+            let indexPaths = array.map { row -> IndexPath in
+                manager.register(items[row].drawer.type)
+                return IndexPath(item: row, section: sectionIndex)
+            }
             tableView.insertRows(at: indexPaths, with: manager.animation)
         case .deletes(let array):
             let indexPaths = array.map { IndexPath(item: $0, section: sectionIndex) }

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -49,6 +49,19 @@ class TestCell: UITableViewCell, ItemCompatible {
     internal var item: Item?
 }
 
+class DifferentItem: Item {
+    
+    var drawer: CellDrawer.Type = DifferentDrawer.self
+}
+
+class DifferentDrawer: CellDrawer {
+    
+    static var type: CellType = .class(DifferentCell.self)
+    static func draw(_ cell: UITableViewCell, with item: Any) {}
+}
+
+class DifferentCell: UITableViewCell { }
+
 class TableViewDataSourceTests: XCTestCase {
     
     fileprivate var tableViewManager: TableViewManager!
@@ -72,6 +85,21 @@ class TableViewDataSourceTests: XCTestCase {
         let cell = self.tableViewManager.tableView(self.tableViewManager.tableView, cellForRowAt: indexPath)
         
         expect(cell).to(beAnInstanceOf(TestCell.self))
+    }
+    
+    func testDequeueCellAfterRegisterSection() {
+        
+        guard let section = tableViewManager.sections.first else {
+            fatalError("Couldn't get the first section")
+        }
+        
+        let otherItem = DifferentItem()
+        section.items.append(otherItem)
+        
+        let indexPath = otherItem.indexPath(in: tableViewManager)!
+        let cell = otherItem.drawer.cell(in: tableViewManager, with: otherItem, for: indexPath)
+        
+        XCTAssertTrue(cell is DifferentCell)
     }
     
     func testNumberOfSections() {

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -56,7 +56,7 @@ class DifferentItem: Item {
 
 class DifferentDrawer: CellDrawer {
     
-    static var type: CellType = .class(DifferentCell.self)
+    static var type: CellType = CellType.class(DifferentCell.self)
     static func draw(_ cell: UITableViewCell, with item: Any) {}
 }
 


### PR DESCRIPTION
Hi team,
I found a little bug, related with register cell. Imagine that you create and insert sections and items when you create a screen.
```swift
let section = TitleSection(title: nil)

let item = TitleItem(title: "Default")
section.items.append(item)

tableViewManager = TableViewManager(tableView: tableView, sections: [section])
```

After that, you decide to insert a different item into the same section. Like this.
```swift
guard let section = tableViewManager?.sections.first else {
    return
}
let item = DifferentItem()
section.items.append(item)
```

In that point, we have a exception because tableview couldn't dequeue the cell. We need to register after insert into the section.

I created a test named **testDequeueCellAfterRegisterSection** to prevent this bug.

Regards