### PR TITLE
Extract UITableViewDataSource and UITableViewDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+---
+
+## [Unreleased]
+### Added
+- Support `UIScrollViewDelegate` from `TableViewManager` via `scrollDelegate`
+
+### Changed
+- Move `UITableViewDataSource` and `UITableViewDelegate` implementations from `TableViewManager` to `TableViewKitDataSource` and `TableViewKitDelegate` which are now the properties: `dataSource` and `delegate`, respectively.

--- a/TableViewKit.xcodeproj/project.pbxproj
+++ b/TableViewKit.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		2564E61C1D88450F00A9DC3E /* TestRegisterHeaderFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2564E61B1D88450F00A9DC3E /* TestRegisterHeaderFooterView.xib */; };
 		25837C781D87F819001EF4B8 /* ItemCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25837C771D87F819001EF4B8 /* ItemCompatible.swift */; };
 		25B0B7541DC74F6C00591467 /* Editable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B0B7531DC74F6C00591467 /* Editable.swift */; };
+		CC09F8891EA79178006FF4EA /* TableViewKitDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC09F8881EA79178006FF4EA /* TableViewKitDataSource.swift */; };
+		CC09F88B1EA791B7006FF4EA /* TableViewKitDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC09F88A1EA791B7006FF4EA /* TableViewKitDelegate.swift */; };
 		CC0DE2C81DE33B9C00E2EDE5 /* AnyEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DE2C71DE33B9C00E2EDE5 /* AnyEquatable.swift */; };
 		CC5CF11C1D839E71004DECB3 /* ArrayDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5CF11B1D839E71004DECB3 /* ArrayDiff.swift */; };
 		CC97D76D1D741DC4009CDF9D /* Selectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC97D76C1D741DC4009CDF9D /* Selectable.swift */; };
@@ -55,6 +57,8 @@
 		25837C771D87F819001EF4B8 /* ItemCompatible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ItemCompatible.swift; path = Protocols/ItemCompatible.swift; sourceTree = "<group>"; };
 		25B0B7531DC74F6C00591467 /* Editable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Editable.swift; path = Protocols/Editable.swift; sourceTree = "<group>"; };
 		4BCAD51C1D89A704002F3420 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "External/Nimble/build/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
+		CC09F8881EA79178006FF4EA /* TableViewKitDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewKitDataSource.swift; sourceTree = "<group>"; };
+		CC09F88A1EA791B7006FF4EA /* TableViewKitDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewKitDelegate.swift; sourceTree = "<group>"; };
 		CC0DE2C71DE33B9C00E2EDE5 /* AnyEquatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnyEquatable.swift; path = Protocols/AnyEquatable.swift; sourceTree = "<group>"; };
 		CC5CF11B1D839E71004DECB3 /* ArrayDiff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayDiff.swift; sourceTree = "<group>"; };
 		CC97D76C1D741DC4009CDF9D /* Selectable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Selectable.swift; path = Protocols/Selectable.swift; sourceTree = "<group>"; };
@@ -155,6 +159,8 @@
 				CCCAC1271D7DA2CF0001FC1D /* Height.swift */,
 				CCEF387D1D8D59C000F5893F /* NibClassType.swift */,
 				CCBE458E1D72F79C00414A64 /* TableViewManager.swift */,
+				CC09F88A1EA791B7006FF4EA /* TableViewKitDelegate.swift */,
+				CC09F8881EA79178006FF4EA /* TableViewKitDataSource.swift */,
 				CCBE455F1D72F69500414A64 /* TableViewKit.h */,
 				CCBE45611D72F69500414A64 /* Info.plist */,
 				CC5CF11B1D839E71004DECB3 /* ArrayDiff.swift */,
@@ -317,6 +323,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CCBE45A01D72F79C00414A64 /* Section.swift in Sources */,
+				CC09F88B1EA791B7006FF4EA /* TableViewKitDelegate.swift in Sources */,
 				CC0DE2C81DE33B9C00E2EDE5 /* AnyEquatable.swift in Sources */,
 				CCFD05CC1D95BD3C0063A002 /* Stateful.swift in Sources */,
 				2519E1C91E013DF00021E06E /* UITableView+Moves.swift in Sources */,
@@ -331,6 +338,7 @@
 				CCDB8FAB1D83649B00E44A99 /* ObservableArray.swift in Sources */,
 				CCCAC1261D7D9EE00001FC1D /* HeaderFooter.swift in Sources */,
 				CCBE45A11D72F79C00414A64 /* TableViewManager.swift in Sources */,
+				CC09F8891EA79178006FF4EA /* TableViewKitDataSource.swift in Sources */,
 				CCBE45931D72F79C00414A64 /* UITableView+Register.swift in Sources */,
 				CCBE459D1D72F79C00414A64 /* CellDrawer.swift in Sources */,
 				CCBE459F1D72F79C00414A64 /* Item.swift in Sources */,

--- a/TableViewKit/Protocols/Selectable.swift
+++ b/TableViewKit/Protocols/Selectable.swift
@@ -18,7 +18,7 @@ extension Selectable {
     public func select(in manager: TableViewManager, animated: Bool, scrollPosition: UITableViewScrollPosition = .none) {
 
         manager.tableView.selectRow(at: indexPath(in: manager), animated: animated, scrollPosition: scrollPosition)
-        manager.tableView(manager.tableView, didSelectRowAt: indexPath(in: manager)!)
+        manager.tableView.delegate?.tableView?(manager.tableView, didSelectRowAt: indexPath(in: manager)!)
     }
 
     /// Deselect the `item`

--- a/TableViewKit/Section.swift
+++ b/TableViewKit/Section.swift
@@ -58,13 +58,13 @@ extension Section {
     /// - parameter manager: A manager where the section may have been added
     internal func register(in manager: TableViewManager) {
         if case .view(let header) = header {
-            manager.tableView.register(type(of: header).drawer.type)
+            manager.register(type(of: header).drawer.type)
         }
         if case .view(let footer) = footer {
-            manager.tableView.register(type(of: footer).drawer.type)
+            manager.register(type(of: footer).drawer.type)
         }
         items.forEach {
-            manager.tableView.register(type(of: $0).drawer.type)
+            manager.register(type(of: $0).drawer.type)
         }
     }
 

--- a/TableViewKit/TableViewKitDataSource.swift
+++ b/TableViewKit/TableViewKitDataSource.swift
@@ -33,15 +33,16 @@ open class TableViewKitDataSource: NSObject, UITableViewDataSource {
 
     /// Implementation of UITableViewDataSource
     open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return title(for: {$0.header}, inSection: section)
+        return title(for: { $0.header }, inSection: section)
     }
 
     /// Implementation of UITableViewDataSource
     open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return title(for: {$0.footer}, inSection: section)
+        return title(for: { $0.footer }, inSection: section)
     }
 
     /// Implementation of UITableViewDataSource
+    // swiftlint:disable:next line_length
     open func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
         // Intentionally blank. Required to use UITableViewRowActions
     }
@@ -50,12 +51,12 @@ open class TableViewKitDataSource: NSObject, UITableViewDataSource {
     open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return manager.item(at: indexPath) is Editable
     }
-    
+
     fileprivate func title(for key: (Section) -> HeaderFooterView, inSection section: Int) -> String? {
         if case .title(let value) = key(sections[section]) {
             return value
         }
         return nil
     }
-    
+
 }

--- a/TableViewKit/TableViewKitDataSource.swift
+++ b/TableViewKit/TableViewKitDataSource.swift
@@ -1,65 +1,65 @@
 import UIKit
 
 public protocol TableViewKitDataSourceType: class, UITableViewDataSource {
-	init(manager: TableViewManager)
+    init(manager: TableViewManager)
 }
 
 open class TableViewKitDataSource: NSObject, TableViewKitDataSourceType {
 
-	open unowned var manager: TableViewManager
-	open var sections: ObservableArray<Section> { return manager.sections }
+    open unowned var manager: TableViewManager
+    open var sections: ObservableArray<Section> { return manager.sections }
 
-	public required init(manager: TableViewManager) {
-		self.manager = manager
-	}
+    public required init(manager: TableViewManager) {
+        self.manager = manager
+    }
 
-	/// Implementation of UITableViewDataSource
-	open func numberOfSections(in tableView: UITableView) -> Int {
-		return sections.count
-	}
+    /// Implementation of UITableViewDataSource
+    open func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
 
-	/// Implementation of UITableViewDataSource
-	open func tableView(_ tableView: UITableView, numberOfRowsInSection sectionIndex: Int) -> Int {
-		let section = sections[sectionIndex]
-		return section.items.count
-	}
+    /// Implementation of UITableViewDataSource
+    open func tableView(_ tableView: UITableView, numberOfRowsInSection sectionIndex: Int) -> Int {
+        let section = sections[sectionIndex]
+        return section.items.count
+    }
 
-	/// Implementation of UITableViewDataSource
-	open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-		let currentItem = manager.item(at: indexPath)
-		let drawer = type(of: currentItem).drawer
+    /// Implementation of UITableViewDataSource
+    open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let currentItem = manager.item(at: indexPath)
+        let drawer = type(of: currentItem).drawer
 
-		let cell = drawer.cell(in: manager, with: currentItem, for: indexPath)
-		drawer.draw(cell, with: currentItem)
+        let cell = drawer.cell(in: manager, with: currentItem, for: indexPath)
+        drawer.draw(cell, with: currentItem)
 
-		return cell
-	}
+        return cell
+    }
 
-	/// Implementation of UITableViewDataSource
-	open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-		return title(for: {$0.header}, inSection: section)
-	}
+    /// Implementation of UITableViewDataSource
+    open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return title(for: {$0.header}, inSection: section)
+    }
 
-	/// Implementation of UITableViewDataSource
-	open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-		return title(for: {$0.footer}, inSection: section)
-	}
+    /// Implementation of UITableViewDataSource
+    open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return title(for: {$0.footer}, inSection: section)
+    }
 
-	/// Implementation of UITableViewDataSource
-	open func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
-		// Intentionally blank. Required to use UITableViewRowActions
-	}
+    /// Implementation of UITableViewDataSource
+    open func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+        // Intentionally blank. Required to use UITableViewRowActions
+    }
 
-	/// Implementation of UITableViewDataSource
-	open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-		return manager.item(at: indexPath) is Editable
-	}
-
-	fileprivate func title(for key: (Section) -> HeaderFooterView, inSection section: Int) -> String? {
-		if case .title(let value) = key(sections[section]) {
-			return value
-		}
-		return nil
-	}
-
+    /// Implementation of UITableViewDataSource
+    open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        return manager.item(at: indexPath) is Editable
+    }
+    
+    fileprivate func title(for key: (Section) -> HeaderFooterView, inSection section: Int) -> String? {
+        if case .title(let value) = key(sections[section]) {
+            return value
+        }
+        return nil
+    }
+    
 }

--- a/TableViewKit/TableViewKitDataSource.swift
+++ b/TableViewKit/TableViewKitDataSource.swift
@@ -3,7 +3,7 @@ import UIKit
 open class TableViewKitDataSource: NSObject, UITableViewDataSource {
 
     open unowned var manager: TableViewManager
-    open var sections: ObservableArray<Section> { return manager.sections }
+    private var sections: ObservableArray<Section> { return manager.sections }
 
     public required init(manager: TableViewManager) {
         self.manager = manager

--- a/TableViewKit/TableViewKitDataSource.swift
+++ b/TableViewKit/TableViewKitDataSource.swift
@@ -1,0 +1,65 @@
+import UIKit
+
+public protocol TableViewKitDataSourceType: class, UITableViewDataSource {
+	init(manager: TableViewManager)
+}
+
+open class TableViewKitDataSource: NSObject, TableViewKitDataSourceType {
+
+	open unowned var manager: TableViewManager
+	open var sections: ObservableArray<Section> { return manager.sections }
+
+	public required init(manager: TableViewManager) {
+		self.manager = manager
+	}
+
+	/// Implementation of UITableViewDataSource
+	open func numberOfSections(in tableView: UITableView) -> Int {
+		return sections.count
+	}
+
+	/// Implementation of UITableViewDataSource
+	open func tableView(_ tableView: UITableView, numberOfRowsInSection sectionIndex: Int) -> Int {
+		let section = sections[sectionIndex]
+		return section.items.count
+	}
+
+	/// Implementation of UITableViewDataSource
+	open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+		let currentItem = manager.item(at: indexPath)
+		let drawer = type(of: currentItem).drawer
+
+		let cell = drawer.cell(in: manager, with: currentItem, for: indexPath)
+		drawer.draw(cell, with: currentItem)
+
+		return cell
+	}
+
+	/// Implementation of UITableViewDataSource
+	open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+		return title(for: {$0.header}, inSection: section)
+	}
+
+	/// Implementation of UITableViewDataSource
+	open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+		return title(for: {$0.footer}, inSection: section)
+	}
+
+	/// Implementation of UITableViewDataSource
+	open func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+		// Intentionally blank. Required to use UITableViewRowActions
+	}
+
+	/// Implementation of UITableViewDataSource
+	open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+		return manager.item(at: indexPath) is Editable
+	}
+
+	fileprivate func title(for key: (Section) -> HeaderFooterView, inSection section: Int) -> String? {
+		if case .title(let value) = key(sections[section]) {
+			return value
+		}
+		return nil
+	}
+
+}

--- a/TableViewKit/TableViewKitDataSource.swift
+++ b/TableViewKit/TableViewKitDataSource.swift
@@ -1,10 +1,6 @@
 import UIKit
 
-public protocol TableViewKitDataSourceType: class, UITableViewDataSource {
-    init(manager: TableViewManager)
-}
-
-open class TableViewKitDataSource: NSObject, TableViewKitDataSourceType {
+open class TableViewKitDataSource: NSObject, UITableViewDataSource {
 
     open unowned var manager: TableViewManager
     open var sections: ObservableArray<Section> { return manager.sections }

--- a/TableViewKit/TableViewKitDelegate.swift
+++ b/TableViewKit/TableViewKitDelegate.swift
@@ -23,12 +23,12 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return height(for: {$0.header}, inSection: section) ?? tableView.sectionHeaderHeight
+        return height(for: { $0.header }, inSection: section) ?? tableView.sectionHeaderHeight
     }
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return height(for: {$0.footer}, inSection: section) ?? tableView.sectionFooterHeight
+        return height(for: { $0.footer }, inSection: section) ?? tableView.sectionFooterHeight
     }
 
     /// Implementation of UITableViewDelegate
@@ -38,22 +38,22 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return estimatedHeight(for: {$0.header}, inSection: section) ?? tableView.estimatedSectionHeaderHeight
+        return estimatedHeight(for: { $0.header }, inSection: section) ?? tableView.estimatedSectionHeaderHeight
     }
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
-        return estimatedHeight(for: {$0.footer}, inSection: section) ?? tableView.estimatedSectionHeaderHeight
+        return estimatedHeight(for: { $0.footer }, inSection: section) ?? tableView.estimatedSectionHeaderHeight
     }
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return view(for: {$0.header}, inSection: section)
+        return view(for: { $0.header }, inSection: section)
     }
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return view(for: {$0.footer}, inSection: section)
+        return view(for: { $0.footer }, inSection: section)
     }
 
     /// Implementation of UITableViewDelegate
@@ -93,7 +93,7 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
         case .view(let view):
             guard let height = view.height else { return nil }
             return height.estimated
-        case .title(_):
+        case .title:
             return 1.0
         default:
             return nil
@@ -110,10 +110,10 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
             else { return nil }
         return value.height
     }
-    
+
     fileprivate func height(at indexPath: IndexPath) -> CGFloat? {
         guard let value = manager.item(at: indexPath).height else { return nil }
         return value.height
     }
-    
+
 }

--- a/TableViewKit/TableViewKitDelegate.swift
+++ b/TableViewKit/TableViewKitDelegate.swift
@@ -4,7 +4,7 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
 
     open unowned var manager: TableViewManager
     open weak var scrollDelegate: UIScrollViewDelegate?
-    open var sections: ObservableArray<Section> { return manager.sections }
+    private var sections: ObservableArray<Section> { return manager.sections }
 
     public required init(manager: TableViewManager) {
         self.manager = manager

--- a/TableViewKit/TableViewKitDelegate.swift
+++ b/TableViewKit/TableViewKitDelegate.swift
@@ -1,12 +1,9 @@
 import UIKit
 
-public protocol TableViewKitDelegateType: class, UITableViewDelegate {
-    init(manager: TableViewManager)
-}
-
-open class TableViewKitDelegate: NSObject, TableViewKitDelegateType {
+open class TableViewKitDelegate: NSObject, UITableViewDelegate {
 
     open unowned var manager: TableViewManager
+    open weak var scrollDelegate: UIScrollViewDelegate?
     open var sections: ObservableArray<Section> { return manager.sections }
 
     public required init(manager: TableViewManager) {
@@ -63,6 +60,21 @@ open class TableViewKitDelegate: NSObject, TableViewKitDelegateType {
     open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
         guard let item = manager.item(at: indexPath) as? Editable else { return nil }
         return item.actions
+    }
+
+    /// Implementation of UIScrollViewDelegate
+    open func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollDelegate?.scrollViewDidScroll?(scrollView)
+    }
+
+    /// Implementation of UIScrollViewDelegate
+    open func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        scrollDelegate?.scrollViewWillBeginDragging?(scrollView)
+    }
+
+    /// Implementation of UIScrollViewDelegate
+    open func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        scrollDelegate?.scrollViewDidEndDragging?(scrollView, willDecelerate: decelerate)
     }
 
     fileprivate func view(for key: (Section) -> HeaderFooterView, inSection section: Int) -> UIView? {

--- a/TableViewKit/TableViewKitDelegate.swift
+++ b/TableViewKit/TableViewKitDelegate.swift
@@ -1,0 +1,107 @@
+import UIKit
+
+public protocol TableViewKitDelegateType: class, UITableViewDelegate {
+	init(manager: TableViewManager)
+}
+
+open class TableViewKitDelegate: NSObject, TableViewKitDelegateType {
+
+	open unowned var manager: TableViewManager
+	open var sections: ObservableArray<Section> { return manager.sections }
+
+	public required init(manager: TableViewManager) {
+		self.manager = manager
+	}
+
+	/// Implementation of UITableViewDelegate
+	open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		guard let currentItem = manager.item(at: indexPath) as? Selectable else { return }
+		currentItem.didSelect()
+	}
+
+	/// Implementation of UITableViewDelegate
+	open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+		return height(at: indexPath) ?? tableView.rowHeight
+	}
+
+	/// Implementation of UITableViewDelegate
+	open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+		return height(for: {$0.header}, inSection: section) ?? tableView.sectionHeaderHeight
+	}
+
+	/// Implementation of UITableViewDelegate
+	open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+		return height(for: {$0.footer}, inSection: section) ?? tableView.sectionFooterHeight
+	}
+
+	/// Implementation of UITableViewDelegate
+	open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+		return estimatedHeight(at: indexPath) ?? tableView.estimatedRowHeight
+	}
+
+	/// Implementation of UITableViewDelegate
+	open func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+		return estimatedHeight(for: {$0.header}, inSection: section) ?? tableView.estimatedSectionHeaderHeight
+	}
+
+	/// Implementation of UITableViewDelegate
+	open func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
+		return estimatedHeight(for: {$0.footer}, inSection: section) ?? tableView.estimatedSectionHeaderHeight
+	}
+
+	/// Implementation of UITableViewDelegate
+	open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+		return view(for: {$0.header}, inSection: section)
+	}
+
+	/// Implementation of UITableViewDelegate
+	open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+		return view(for: {$0.footer}, inSection: section)
+	}
+
+	/// Implementation of UITableViewDelegate
+	open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+		guard let item = manager.item(at: indexPath) as? Editable else { return nil }
+		return item.actions
+	}
+
+	fileprivate func view(for key: (Section) -> HeaderFooterView, inSection section: Int) -> UIView? {
+		guard case .view(let item) = key(sections[section]) else { return nil }
+
+		let drawer = type(of: item).drawer
+		let view = drawer.view(in: manager, with: item)
+		drawer.draw(view, with: item)
+
+		return view
+	}
+
+	fileprivate func estimatedHeight(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
+		let item = key(sections[section])
+		switch item {
+		case .view(let view):
+			guard let height = view.height else { return nil }
+			return height.estimated
+		case .title(_):
+			return 1.0
+		default:
+			return nil
+		}
+	}
+
+	fileprivate func estimatedHeight(at indexPath: IndexPath) -> CGFloat? {
+		guard let height = manager.item(at: indexPath).height else { return nil }
+		return height.estimated
+	}
+
+	fileprivate func height(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
+		guard case .view(let view) = key(sections[section]), let value = view.height
+			else { return nil }
+		return value.height
+	}
+
+	fileprivate func height(at indexPath: IndexPath) -> CGFloat? {
+		guard let value = manager.item(at: indexPath).height else { return nil }
+		return value.height
+	}
+
+}

--- a/TableViewKit/TableViewKitDelegate.swift
+++ b/TableViewKit/TableViewKitDelegate.swift
@@ -1,107 +1,107 @@
 import UIKit
 
 public protocol TableViewKitDelegateType: class, UITableViewDelegate {
-	init(manager: TableViewManager)
+    init(manager: TableViewManager)
 }
 
 open class TableViewKitDelegate: NSObject, TableViewKitDelegateType {
 
-	open unowned var manager: TableViewManager
-	open var sections: ObservableArray<Section> { return manager.sections }
+    open unowned var manager: TableViewManager
+    open var sections: ObservableArray<Section> { return manager.sections }
 
-	public required init(manager: TableViewManager) {
-		self.manager = manager
-	}
+    public required init(manager: TableViewManager) {
+        self.manager = manager
+    }
 
-	/// Implementation of UITableViewDelegate
-	open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-		guard let currentItem = manager.item(at: indexPath) as? Selectable else { return }
-		currentItem.didSelect()
-	}
+    /// Implementation of UITableViewDelegate
+    open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let currentItem = manager.item(at: indexPath) as? Selectable else { return }
+        currentItem.didSelect()
+    }
 
-	/// Implementation of UITableViewDelegate
-	open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-		return height(at: indexPath) ?? tableView.rowHeight
-	}
+    /// Implementation of UITableViewDelegate
+    open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return height(at: indexPath) ?? tableView.rowHeight
+    }
 
-	/// Implementation of UITableViewDelegate
-	open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-		return height(for: {$0.header}, inSection: section) ?? tableView.sectionHeaderHeight
-	}
+    /// Implementation of UITableViewDelegate
+    open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return height(for: {$0.header}, inSection: section) ?? tableView.sectionHeaderHeight
+    }
 
-	/// Implementation of UITableViewDelegate
-	open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-		return height(for: {$0.footer}, inSection: section) ?? tableView.sectionFooterHeight
-	}
+    /// Implementation of UITableViewDelegate
+    open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return height(for: {$0.footer}, inSection: section) ?? tableView.sectionFooterHeight
+    }
 
-	/// Implementation of UITableViewDelegate
-	open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-		return estimatedHeight(at: indexPath) ?? tableView.estimatedRowHeight
-	}
+    /// Implementation of UITableViewDelegate
+    open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return estimatedHeight(at: indexPath) ?? tableView.estimatedRowHeight
+    }
 
-	/// Implementation of UITableViewDelegate
-	open func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-		return estimatedHeight(for: {$0.header}, inSection: section) ?? tableView.estimatedSectionHeaderHeight
-	}
+    /// Implementation of UITableViewDelegate
+    open func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return estimatedHeight(for: {$0.header}, inSection: section) ?? tableView.estimatedSectionHeaderHeight
+    }
 
-	/// Implementation of UITableViewDelegate
-	open func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
-		return estimatedHeight(for: {$0.footer}, inSection: section) ?? tableView.estimatedSectionHeaderHeight
-	}
+    /// Implementation of UITableViewDelegate
+    open func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
+        return estimatedHeight(for: {$0.footer}, inSection: section) ?? tableView.estimatedSectionHeaderHeight
+    }
 
-	/// Implementation of UITableViewDelegate
-	open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-		return view(for: {$0.header}, inSection: section)
-	}
+    /// Implementation of UITableViewDelegate
+    open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return view(for: {$0.header}, inSection: section)
+    }
 
-	/// Implementation of UITableViewDelegate
-	open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-		return view(for: {$0.footer}, inSection: section)
-	}
+    /// Implementation of UITableViewDelegate
+    open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return view(for: {$0.footer}, inSection: section)
+    }
 
-	/// Implementation of UITableViewDelegate
-	open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-		guard let item = manager.item(at: indexPath) as? Editable else { return nil }
-		return item.actions
-	}
+    /// Implementation of UITableViewDelegate
+    open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+        guard let item = manager.item(at: indexPath) as? Editable else { return nil }
+        return item.actions
+    }
 
-	fileprivate func view(for key: (Section) -> HeaderFooterView, inSection section: Int) -> UIView? {
-		guard case .view(let item) = key(sections[section]) else { return nil }
+    fileprivate func view(for key: (Section) -> HeaderFooterView, inSection section: Int) -> UIView? {
+        guard case .view(let item) = key(sections[section]) else { return nil }
 
-		let drawer = type(of: item).drawer
-		let view = drawer.view(in: manager, with: item)
-		drawer.draw(view, with: item)
+        let drawer = type(of: item).drawer
+        let view = drawer.view(in: manager, with: item)
+        drawer.draw(view, with: item)
 
-		return view
-	}
+        return view
+    }
 
-	fileprivate func estimatedHeight(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
-		let item = key(sections[section])
-		switch item {
-		case .view(let view):
-			guard let height = view.height else { return nil }
-			return height.estimated
-		case .title(_):
-			return 1.0
-		default:
-			return nil
-		}
-	}
+    fileprivate func estimatedHeight(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
+        let item = key(sections[section])
+        switch item {
+        case .view(let view):
+            guard let height = view.height else { return nil }
+            return height.estimated
+        case .title(_):
+            return 1.0
+        default:
+            return nil
+        }
+    }
 
-	fileprivate func estimatedHeight(at indexPath: IndexPath) -> CGFloat? {
-		guard let height = manager.item(at: indexPath).height else { return nil }
-		return height.estimated
-	}
+    fileprivate func estimatedHeight(at indexPath: IndexPath) -> CGFloat? {
+        guard let height = manager.item(at: indexPath).height else { return nil }
+        return height.estimated
+    }
 
-	fileprivate func height(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
-		guard case .view(let view) = key(sections[section]), let value = view.height
-			else { return nil }
-		return value.height
-	}
-
-	fileprivate func height(at indexPath: IndexPath) -> CGFloat? {
-		guard let value = manager.item(at: indexPath).height else { return nil }
-		return value.height
-	}
-
+    fileprivate func height(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
+        guard case .view(let view) = key(sections[section]), let value = view.height
+            else { return nil }
+        return value.height
+    }
+    
+    fileprivate func height(at indexPath: IndexPath) -> CGFloat? {
+        guard let value = manager.item(at: indexPath).height else { return nil }
+        return value.height
+    }
+    
 }

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -18,8 +18,8 @@ open class TableViewManager {
 
     open var animation: UITableViewRowAnimation = .automatic
 
-    open var dataSource: TableViewKitDataSourceType?
-    open var delegate: TableViewKitDelegateType?
+    open var dataSource: TableViewKitDataSourceType? { didSet { tableView.dataSource = dataSource } }
+    open var delegate: TableViewKitDelegateType? { didSet { tableView.delegate = delegate } }
 
     var reusableIdentifiers: Set<String> = []
 

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -34,12 +34,12 @@ open class TableViewManager {
     }
 
     private func setupDelegate() {
-        self.delegate = TableViewKitDelegate.init(manager: self)
+        self.delegate = TableViewKitDelegate(manager: self)
         self.tableView.delegate = self.delegate
     }
 
     private func setupDataSource() {
-        self.dataSource = TableViewKitDataSource.init(manager: self)
+        self.dataSource = TableViewKitDataSource(manager: self)
         self.tableView.dataSource = self.dataSource
     }
 
@@ -68,13 +68,13 @@ open class TableViewManager {
             let toIndex = array.map { $0.1 }
             tableView.moveSections(from: fromIndex, to: toIndex)
         case .beginUpdates:
-            if (animation == .none) {
+            if animation == .none {
                 UIView.setAnimationsEnabled(false)
             }
             tableView.beginUpdates()
         case .endUpdates:
             tableView.endUpdates()
-            if (animation == .none) {
+            if animation == .none {
                 UIView.setAnimationsEnabled(true)
             }
         }
@@ -96,7 +96,7 @@ extension TableViewManager {
             reusableIdentifiers.insert(type.reusableIdentifier)
         }
     }
-    
+
     func item(at indexPath: IndexPath) -> Item {
         return sections[indexPath.section].items[indexPath.row]
     }

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -18,8 +18,8 @@ open class TableViewManager {
 
     open var animation: UITableViewRowAnimation = .automatic
 
-    public var dataSource: TableViewKitDataSourceType?
-    public var delegate: TableViewKitDelegateType?
+    open var dataSource: TableViewKitDataSourceType?
+    open var delegate: TableViewKitDelegateType?
 
     var reusableIdentifiers: Set<String> = []
 

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -13,13 +13,11 @@ open class TableViewManager {
     /// An array of sections
     open var sections: ObservableArray<Section>
 
-    open var dataSourceClass: TableViewKitDataSourceType.Type { return TableViewKitDataSource.self }
-    open var delegateClass: TableViewKitDelegateType.Type { return TableViewKitDelegate.self }
-
     open var animation: UITableViewRowAnimation = .automatic
 
-    open var dataSource: TableViewKitDataSourceType? { didSet { tableView.dataSource = dataSource } }
-    open var delegate: TableViewKitDelegateType? { didSet { tableView.delegate = delegate } }
+    open var dataSource: TableViewKitDataSource? { didSet { tableView.dataSource = dataSource } }
+    open var delegate: TableViewKitDelegate? { didSet { tableView.delegate = delegate } }
+    open var scrollDelegate: UIScrollViewDelegate? { didSet { delegate?.scrollDelegate = scrollDelegate } }
 
     var reusableIdentifiers: Set<String> = []
 
@@ -36,12 +34,12 @@ open class TableViewManager {
     }
 
     private func setupDelegate() {
-        self.delegate = delegateClass.init(manager: self)
+        self.delegate = TableViewKitDelegate.init(manager: self)
         self.tableView.delegate = self.delegate
     }
 
     private func setupDataSource() {
-        self.dataSource = dataSourceClass.init(manager: self)
+        self.dataSource = TableViewKitDataSource.init(manager: self)
         self.tableView.dataSource = self.dataSource
     }
 

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -11,15 +11,15 @@ open class TableViewManager {
     open let tableView: UITableView
 
     /// An array of sections
-	open var sections: ObservableArray<Section>
+    open var sections: ObservableArray<Section>
 
-	open var dataSourceClass: TableViewKitDataSourceType.Type { return TableViewKitDataSource.self }
-	open var delegateClass: TableViewKitDelegateType.Type { return TableViewKitDelegate.self }
+    open var dataSourceClass: TableViewKitDataSourceType.Type { return TableViewKitDataSource.self }
+    open var delegateClass: TableViewKitDelegateType.Type { return TableViewKitDelegate.self }
 
     open var animation: UITableViewRowAnimation = .automatic
 
-	public var dataSource: TableViewKitDataSourceType?
-	public var delegate: TableViewKitDelegateType?
+    public var dataSource: TableViewKitDataSourceType?
+    public var delegate: TableViewKitDelegateType?
 
     var reusableIdentifiers: Set<String> = []
 
@@ -30,20 +30,20 @@ open class TableViewManager {
     public init(tableView: UITableView, sections: [Section] = []) {
         self.tableView = tableView
         self.sections = ObservableArray(array: sections)
-		self.setupDelegate()
-		self.setupDataSource()
+        self.setupDelegate()
+        self.setupDataSource()
         self.setupSections()
     }
 
-	private func setupDelegate() {
-		self.delegate = delegateClass.init(manager: self)
-		self.tableView.delegate = self.delegate
-	}
+    private func setupDelegate() {
+        self.delegate = delegateClass.init(manager: self)
+        self.tableView.delegate = self.delegate
+    }
 
-	private func setupDataSource() {
-		self.dataSource = dataSourceClass.init(manager: self)
-		self.tableView.dataSource = self.dataSource
-	}
+    private func setupDataSource() {
+        self.dataSource = dataSourceClass.init(manager: self)
+        self.tableView.dataSource = self.dataSource
+    }
 
     private func setupSections() {
         sections.forEach { section in
@@ -98,8 +98,8 @@ extension TableViewManager {
             reusableIdentifiers.insert(type.reusableIdentifier)
         }
     }
-
-	func item(at indexPath: IndexPath) -> Item {
-		return sections[indexPath.section].items[indexPath.row]
-	}
+    
+    func item(at indexPath: IndexPath) -> Item {
+        return sections[indexPath.section].items[indexPath.row]
+    }
 }

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -5,13 +5,17 @@ import UIKit
 /// It controls how to display an array of sections, from the header, to its items, to the footer.
 /// It automatically registers any related initial or new views/cells for reusability.
 /// Any changes of the sections will be automatically animated and reflected.
-open class TableViewManager: NSObject {
+open class TableViewManager {
 
     /// The `tableView` linked to this manager
     open let tableView: UITableView
 
     /// An array of sections
     open var sections: ObservableArray<Section>
+
+	open var dataSource: TableViewKitDataSource?
+
+	open var delegate: TableViewKitDelegate?
 
     open var animation: UITableViewRowAnimation = .automatic
 
@@ -23,9 +27,10 @@ open class TableViewManager: NSObject {
     public init(tableView: UITableView) {
         self.tableView = tableView
         self.sections = []
-        super.init()
-        self.tableView.dataSource = self
-        self.tableView.delegate = self
+		self.dataSource = TableViewKitDataSource(manager: self)
+		self.delegate = TableViewKitDelegate(manager: self)
+        self.tableView.dataSource = self.dataSource
+        self.tableView.delegate = self.delegate
         self.setupSections()
 
     }
@@ -37,9 +42,10 @@ open class TableViewManager: NSObject {
     public init(tableView: UITableView, sections: [Section]) {
         self.tableView = tableView
         self.sections = ObservableArray(array: sections)
-        super.init()
-        self.tableView.dataSource = self
-        self.tableView.delegate = self
+		self.dataSource = TableViewKitDataSource(manager: self)
+		self.delegate = TableViewKitDelegate(manager: self)
+		self.tableView.dataSource = self.dataSource
+		self.tableView.delegate = self.delegate
         self.setupSections()
     }
 
@@ -68,13 +74,13 @@ open class TableViewManager: NSObject {
             let toIndex = array.map { $0.1 }
             tableView.moveSections(from: fromIndex, to: toIndex)
         case .beginUpdates:
-            if animation == .none {
+            if (animation == .none) {
                 UIView.setAnimationsEnabled(false)
             }
             tableView.beginUpdates()
         case .endUpdates:
             tableView.endUpdates()
-            if animation == .none {
+            if (animation == .none) {
                 UIView.setAnimationsEnabled(true)
             }
         }
@@ -98,62 +104,15 @@ extension TableViewManager {
     }
 }
 
-extension TableViewManager {
+open class TableViewKitDataSource: NSObject, UITableViewDataSource {
 
-    fileprivate func item(at indexPath: IndexPath) -> Item {
-        return sections[indexPath.section].items[indexPath.row]
-    }
+	open unowned var manager: TableViewManager
+	open var sections: ObservableArray<Section> { return manager.sections }
 
-    fileprivate func view(for key: (Section) -> HeaderFooterView, inSection section: Int) -> UIView? {
-        guard case .view(let item) = key(sections[section]) else { return nil }
+	public init(manager: TableViewManager) {
+		self.manager = manager
+	}
 
-        let drawer = type(of: item).drawer
-        let view = drawer.view(in: self, with: item)
-        drawer.draw(view, with: item)
-
-        return view
-    }
-
-    fileprivate func title(for key: (Section) -> HeaderFooterView, inSection section: Int) -> String? {
-        if case .title(let value) = key(sections[section]) {
-            return value
-        }
-        return nil
-
-    }
-
-    fileprivate func estimatedHeight(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
-        let item = key(sections[section])
-        switch item {
-        case .view(let view):
-            guard let height = view.height else { return nil }
-            return height.estimated
-        case .title:
-            return 1.0
-        default:
-            return nil
-        }
-    }
-
-    fileprivate func estimatedHeight(at indexPath: IndexPath) -> CGFloat? {
-        guard let height = item(at: indexPath).height else { return nil }
-        return height.estimated
-    }
-
-    fileprivate func height(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
-        guard case .view(let view) = key(sections[section]), let value = view.height
-            else { return nil }
-        return value.height
-    }
-
-    fileprivate func height(at indexPath: IndexPath) -> CGFloat? {
-        guard let value = item(at: indexPath).height else { return nil }
-        return value.height
-    }
-
-}
-
-extension TableViewManager: UITableViewDataSource {
 
     /// Implementation of UITableViewDataSource
     open func numberOfSections(in tableView: UITableView) -> Int {
@@ -171,7 +130,7 @@ extension TableViewManager: UITableViewDataSource {
         let currentItem = item(at: indexPath)
         let drawer = type(of: currentItem).drawer
 
-        let cell = drawer.cell(in: self, with: currentItem, for: indexPath)
+        let cell = drawer.cell(in: manager, with: currentItem, for: indexPath)
         drawer.draw(cell, with: currentItem)
 
         return cell
@@ -179,22 +138,44 @@ extension TableViewManager: UITableViewDataSource {
 
     /// Implementation of UITableViewDataSource
     open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return title(for: { $0.header }, inSection: section)
+        return title(for: {$0.header}, inSection: section)
     }
 
     /// Implementation of UITableViewDataSource
     open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return title(for: { $0.footer }, inSection: section)
+        return title(for: {$0.footer}, inSection: section)
     }
 
     /// Implementation of UITableViewDataSource
-    // swiftlint:disable:next line_length
     open func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
         // Intentionally blank. Required to use UITableViewRowActions
     }
+
+	/// Implementation of UITableViewDataSource
+	open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+		return item(at: indexPath) is Editable
+	}
+
+	fileprivate func title(for key: (Section) -> HeaderFooterView, inSection section: Int) -> String? {
+		if case .title(let value) = key(sections[section]) {
+			return value
+		}
+		return nil
+	}
+
+	fileprivate func item(at indexPath: IndexPath) -> Item {
+		return sections[indexPath.section].items[indexPath.row]
+	}
 }
 
-extension TableViewManager: UITableViewDelegate {
+open class TableViewKitDelegate: NSObject, UITableViewDelegate {
+
+	open unowned var manager: TableViewManager
+	open var sections: ObservableArray<Section> { return manager.sections }
+
+	public init(manager: TableViewManager) {
+		self.manager = manager
+	}
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -209,12 +190,12 @@ extension TableViewManager: UITableViewDelegate {
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return height(for: { $0.header }, inSection: section) ?? tableView.sectionHeaderHeight
+        return height(for: {$0.header}, inSection: section) ?? tableView.sectionHeaderHeight
     }
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return height(for: { $0.footer }, inSection: section) ?? tableView.sectionFooterHeight
+        return height(for: {$0.footer}, inSection: section) ?? tableView.sectionFooterHeight
     }
 
     /// Implementation of UITableViewDelegate
@@ -224,31 +205,72 @@ extension TableViewManager: UITableViewDelegate {
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return estimatedHeight(for: { $0.header }, inSection: section) ?? tableView.estimatedSectionHeaderHeight
+        return estimatedHeight(for: {$0.header}, inSection: section) ?? tableView.estimatedSectionHeaderHeight
     }
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
-        return estimatedHeight(for: { $0.footer }, inSection: section) ?? tableView.estimatedSectionHeaderHeight
+        return estimatedHeight(for: {$0.footer}, inSection: section) ?? tableView.estimatedSectionHeaderHeight
     }
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return view(for: { $0.header }, inSection: section)
+        return view(for: {$0.header}, inSection: section)
     }
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return view(for: { $0.footer }, inSection: section)
+        return view(for: {$0.footer}, inSection: section)
     }
-
-	open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-		return item(at: indexPath) is Editable
-	}
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
         guard let item = item(at: indexPath) as? Editable else { return nil }
         return item.actions
     }
+
+	fileprivate func item(at indexPath: IndexPath) -> Item {
+		return sections[indexPath.section].items[indexPath.row]
+	}
+
+	fileprivate func view(for key: (Section) -> HeaderFooterView, inSection section: Int) -> UIView? {
+		guard case .view(let item) = key(sections[section]) else { return nil }
+
+		let drawer = type(of: item).drawer
+		let view = drawer.view(in: manager, with: item)
+		drawer.draw(view, with: item)
+
+		return view
+	}
+
+	fileprivate func estimatedHeight(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
+		let item = key(sections[section])
+		switch item {
+		case .view(let view):
+			guard let height = view.height else { return nil }
+			return height.estimated
+		case .title(_):
+			return 1.0
+		default:
+			return nil
+		}
+	}
+
+	fileprivate func estimatedHeight(at indexPath: IndexPath) -> CGFloat? {
+		guard let height = item(at: indexPath).height else { return nil }
+		return height.estimated
+	}
+
+	fileprivate func height(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
+		guard case .view(let view) = key(sections[section]), let value = view.height
+			else { return nil }
+		return value.height
+	}
+
+	fileprivate func height(at indexPath: IndexPath) -> CGFloat? {
+		guard let value = item(at: indexPath).height else { return nil }
+		return value.height
+	}
+
 }
+

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -28,19 +28,13 @@ open class TableViewManager {
     public init(tableView: UITableView, sections: [Section] = []) {
         self.tableView = tableView
         self.sections = ObservableArray(array: sections)
-        self.setupDelegate()
-        self.setupDataSource()
+        self.setupDelegates()
         self.setupSections()
     }
 
-    private func setupDelegate() {
+    private func setupDelegates() {
         self.delegate = TableViewKitDelegate(manager: self)
-        self.tableView.delegate = self.delegate
-    }
-
-    private func setupDataSource() {
         self.dataSource = TableViewKitDataSource(manager: self)
-        self.tableView.dataSource = self.dataSource
     }
 
     private func setupSections() {

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -63,6 +63,8 @@ class DifferentCell: UITableViewCell { }
 class TableViewDataSourceTests: XCTestCase {
 
     fileprivate var tableViewManager: TableViewManager!
+	fileprivate var dataSource: TableViewKitDataSource { return tableViewManager.tableView.dataSource as! TableViewKitDataSource }
+
 
     override func setUp() {
         super.setUp()
@@ -80,7 +82,7 @@ class TableViewDataSourceTests: XCTestCase {
 
     func testCellForRow() {
         let indexPath = IndexPath(row: 0, section: 0)
-        let cell = self.tableViewManager.tableView(self.tableViewManager.tableView, cellForRowAt: indexPath)
+        let cell = dataSource.tableView(self.tableViewManager.tableView, cellForRowAt: indexPath)
 
         expect(cell).to(beAnInstanceOf(TestCell.self))
     }
@@ -102,45 +104,32 @@ class TableViewDataSourceTests: XCTestCase {
     }
 
     func testNumberOfSections() {
-        let count = self.tableViewManager.numberOfSections(in: self.tableViewManager.tableView)
-        expect(count) == 2
+        let count = dataSource.numberOfSections(in: self.tableViewManager.tableView)
+        expect(count).to(equal(2))
     }
 
     func testNumberOfRowsInSection() {
-        let count = self.tableViewManager.tableView(self.tableViewManager.tableView, numberOfRowsInSection: 0)
+        let count = dataSource.tableView(self.tableViewManager.tableView, numberOfRowsInSection: 0)
         expect(count) == 1
     }
 
     func testTitleForHeaderInSection() {
-        let title = self.tableViewManager.tableView(self.tableViewManager.tableView, titleForHeaderInSection: 0)!
+        let title = dataSource.tableView(self.tableViewManager.tableView, titleForHeaderInSection: 0)!
         let section = tableViewManager.sections.first!
 
-        expect(HeaderFooterView.title(title)) == section.header
+        expect(HeaderFooterView.title(title)).to(equal(section.header))
     }
 
     func testTitleForFooterInSection() {
         var title: String?
 
-        title = self.tableViewManager.tableView(self.tableViewManager.tableView, titleForFooterInSection: 0)
+        title = dataSource.tableView(self.tableViewManager.tableView, titleForFooterInSection: 0)
 
         let section = tableViewManager.sections.first!
-        expect(HeaderFooterView.title(title!)) == section.footer
+        expect(HeaderFooterView.title(title!)).to(equal(section.footer))
 
-        title = self.tableViewManager.tableView(self.tableViewManager.tableView, titleForFooterInSection: 1)
+        title = dataSource.tableView(self.tableViewManager.tableView, titleForFooterInSection: 1)
         expect(title).to(beNil())
     }
 
-    func testViewForHeaderInSection() {
-        let view = self.tableViewManager.tableView(self.tableViewManager.tableView, viewForHeaderInSection: 0)
-        expect(view).to(beNil())
-    }
-
-    func testViewForFooterInSection() {
-        var view: UIView?
-        view = self.tableViewManager.tableView(self.tableViewManager.tableView, viewForFooterInSection: 0)
-        expect(view).to(beNil())
-
-        view = self.tableViewManager.tableView(self.tableViewManager.tableView, viewForFooterInSection: 1)
-        expect(view).notTo(beNil())
-    }
 }

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -63,7 +63,7 @@ class DifferentCell: UITableViewCell { }
 class TableViewDataSourceTests: XCTestCase {
 
     fileprivate var tableViewManager: TableViewManager!
-	fileprivate var dataSource: TableViewKitDataSource { return tableViewManager.tableView.dataSource as! TableViewKitDataSource }
+	fileprivate var dataSource: TableViewKitDataSource { return tableViewManager.dataSource as! TableViewKitDataSource }
 
 
     override func setUp() {

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -65,7 +65,6 @@ class TableViewDataSourceTests: XCTestCase {
     fileprivate var tableViewManager: TableViewManager!
     fileprivate var dataSource: TableViewKitDataSource { return tableViewManager.dataSource! }
 
-
     override func setUp() {
         super.setUp()
 
@@ -105,7 +104,7 @@ class TableViewDataSourceTests: XCTestCase {
 
     func testNumberOfSections() {
         let count = dataSource.numberOfSections(in: self.tableViewManager.tableView)
-        expect(count).to(equal(2))
+        expect(count) == 2
     }
 
     func testNumberOfRowsInSection() {
@@ -117,7 +116,7 @@ class TableViewDataSourceTests: XCTestCase {
         let title = dataSource.tableView(self.tableViewManager.tableView, titleForHeaderInSection: 0)!
         let section = tableViewManager.sections.first!
 
-        expect(HeaderFooterView.title(title)).to(equal(section.header))
+        expect(HeaderFooterView.title(title)) == section.header
     }
 
     func testTitleForFooterInSection() {
@@ -126,10 +125,10 @@ class TableViewDataSourceTests: XCTestCase {
         title = dataSource.tableView(self.tableViewManager.tableView, titleForFooterInSection: 0)
 
         let section = tableViewManager.sections.first!
-        expect(HeaderFooterView.title(title!)).to(equal(section.footer))
-        
+        expect(HeaderFooterView.title(title!)) == section.footer
+
         title = dataSource.tableView(self.tableViewManager.tableView, titleForFooterInSection: 1)
         expect(title).to(beNil())
     }
-    
+
 }

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -63,7 +63,7 @@ class DifferentCell: UITableViewCell { }
 class TableViewDataSourceTests: XCTestCase {
 
     fileprivate var tableViewManager: TableViewManager!
-	fileprivate var dataSource: TableViewKitDataSource { return tableViewManager.dataSource as! TableViewKitDataSource }
+    fileprivate var dataSource: TableViewKitDataSource { return tableViewManager.dataSource as! TableViewKitDataSource }
 
 
     override func setUp() {
@@ -97,8 +97,8 @@ class TableViewDataSourceTests: XCTestCase {
         section.items.append(otherItem)
 
         let indexPath = otherItem.indexPath(in: tableViewManager)!
-		let drawer = type(of: otherItem).drawer
-		let cell = drawer.cell(in: tableViewManager, with: otherItem as Item, for: indexPath)
+        let drawer = type(of: otherItem).drawer
+        let cell = drawer.cell(in: tableViewManager, with: otherItem as Item, for: indexPath)
 
         XCTAssertTrue(cell is DifferentCell)
     }
@@ -127,9 +127,9 @@ class TableViewDataSourceTests: XCTestCase {
 
         let section = tableViewManager.sections.first!
         expect(HeaderFooterView.title(title!)).to(equal(section.footer))
-
+        
         title = dataSource.tableView(self.tableViewManager.tableView, titleForFooterInSection: 1)
         expect(title).to(beNil())
     }
-
+    
 }

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -63,7 +63,7 @@ class DifferentCell: UITableViewCell { }
 class TableViewDataSourceTests: XCTestCase {
 
     fileprivate var tableViewManager: TableViewManager!
-    fileprivate var dataSource: TableViewKitDataSource { return tableViewManager.dataSource as! TableViewKitDataSource }
+    fileprivate var dataSource: TableViewKitDataSource { return tableViewManager.dataSource! }
 
 
     override func setUp() {

--- a/TableViewKitTests/TableViewDelegateTests.swift
+++ b/TableViewKitTests/TableViewDelegateTests.swift
@@ -90,7 +90,7 @@ class EditableItem: SelectableItem, Editable {
 class TableViewDelegateTests: XCTestCase {
 
     fileprivate var tableViewManager: TableViewManager!
-	fileprivate var delegate: TableViewKitDelegate { return tableViewManager.delegate as! TableViewKitDelegate }
+    fileprivate var delegate: TableViewKitDelegate { return tableViewManager.delegate as! TableViewKitDelegate }
 
     override func setUp() {
         super.setUp()
@@ -217,21 +217,21 @@ class TableViewDelegateTests: XCTestCase {
         XCTAssert(actions!.count == 1)
     }
 
-	func testViewForHeaderInSection() {
-		let view = delegate.tableView(self.tableViewManager.tableView, viewForHeaderInSection: 0)
-		expect(view).to(beNil())
-	}
+    func testViewForHeaderInSection() {
+        let view = delegate.tableView(self.tableViewManager.tableView, viewForHeaderInSection: 0)
+        expect(view).to(beNil())
+    }
 
-	func testViewForFooterInSection() {
-		var view: UIView?
-		view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 0)
-		expect(view).to(beNil())
-
-		view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 1)
-		expect(view).to(beNil())
-
-		view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 2)
-		expect(view).toNot(beNil())
-
-	}
+    func testViewForFooterInSection() {
+        var view: UIView?
+        view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 0)
+        expect(view).to(beNil())
+        
+        view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 1)
+        expect(view).to(beNil())
+        
+        view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 2)
+        expect(view).toNot(beNil())
+        
+    }
 }

--- a/TableViewKitTests/TableViewDelegateTests.swift
+++ b/TableViewKitTests/TableViewDelegateTests.swift
@@ -89,7 +89,8 @@ class EditableItem: SelectableItem, Editable {
 
 class TableViewDelegateTests: XCTestCase {
 
-    private var tableViewManager: TableViewManager!
+    fileprivate var tableViewManager: TableViewManager!
+	fileprivate var delegate: TableViewKitDelegate { return tableViewManager.tableView.delegate as! TableViewKitDelegate }
 
     override func setUp() {
         super.setUp()
@@ -109,41 +110,41 @@ class TableViewDelegateTests: XCTestCase {
     func testEstimatedHeightForHeader() {
         var height: CGFloat
 
-        height = tableViewManager.tableView(tableViewManager.tableView, estimatedHeightForHeaderInSection: 0)
-        expect(height) > 0.0
+        height = delegate.tableView(tableViewManager.tableView, estimatedHeightForHeaderInSection: 0)
+        expect(height).to(beGreaterThan(0.0))
 
-        height = tableViewManager.tableView(tableViewManager.tableView, estimatedHeightForHeaderInSection: 1)
-        expect(height) == tableViewManager.tableView.estimatedSectionHeaderHeight
+        height = delegate.tableView(tableViewManager.tableView, estimatedHeightForHeaderInSection: 1)
+        expect(height).to(equal(tableViewManager.tableView.estimatedSectionHeaderHeight))
     }
 
     func testHeightForHeader() {
         var height: CGFloat
 
-        height = tableViewManager.tableView(tableViewManager.tableView, heightForHeaderInSection: 0)
-        expect(height) == UITableViewAutomaticDimension
+        height = delegate.tableView(tableViewManager.tableView, heightForHeaderInSection: 0)
+        expect(height).to(equal(UITableViewAutomaticDimension))
     }
 
     func testEstimatedHeightForFooter() {
         var height: CGFloat
 
-        height = tableViewManager.tableView(tableViewManager.tableView, estimatedHeightForFooterInSection: 0)
-        expect(height) > 0.0
+        height = delegate.tableView(tableViewManager.tableView, estimatedHeightForFooterInSection: 0)
+        expect(height).to(beGreaterThan(0.0))
 
-        height = tableViewManager.tableView(tableViewManager.tableView, estimatedHeightForFooterInSection: 1)
-        expect(height) == tableViewManager.tableView.estimatedSectionFooterHeight
+        height = delegate.tableView(tableViewManager.tableView, estimatedHeightForFooterInSection: 1)
+        expect(height).to(equal(tableViewManager.tableView.estimatedSectionFooterHeight))
 
-        height = tableViewManager.tableView(tableViewManager.tableView, estimatedHeightForFooterInSection: 2)
-        expect(height) == 44.0
+        height = delegate.tableView(tableViewManager.tableView, estimatedHeightForFooterInSection: 2)
+        expect(height).to(equal(44.0))
     }
 
     func testHeightForFooter() {
         var height: CGFloat
 
-        height = tableViewManager.tableView(tableViewManager.tableView, heightForFooterInSection: 0)
-        expect(height) == UITableViewAutomaticDimension
+        height = delegate.tableView(tableViewManager.tableView, heightForFooterInSection: 0)
+        expect(height).to(equal(UITableViewAutomaticDimension))
 
-        height = tableViewManager.tableView(tableViewManager.tableView, heightForFooterInSection: 2)
-        expect(height) == UITableViewAutomaticDimension
+        height = delegate.tableView(tableViewManager.tableView, heightForFooterInSection: 2)
+        expect(height).to(equal(UITableViewAutomaticDimension))
     }
 
     func testEstimatedHeightForRowAtIndexPath() {
@@ -151,16 +152,16 @@ class TableViewDelegateTests: XCTestCase {
         var indexPath: IndexPath
 
         indexPath = IndexPath(row: 0, section: 0)
-        height = tableViewManager.tableView(tableViewManager.tableView, estimatedHeightForRowAt: indexPath)
-        expect(height) == 44.0
+        height = delegate.tableView(tableViewManager.tableView, estimatedHeightForRowAt: indexPath)
+        expect(height).to(equal(44.0))
 
         indexPath = IndexPath(row: 0, section: 1)
-        height = tableViewManager.tableView(tableViewManager.tableView, estimatedHeightForRowAt: indexPath)
-        expect(height) == tableViewManager.tableView.estimatedRowHeight
+        height = delegate.tableView(tableViewManager.tableView, estimatedHeightForRowAt: indexPath)
+        expect(height).to(equal(tableViewManager.tableView.estimatedRowHeight))
 
         indexPath = IndexPath(row: 1, section: 1)
-        height = tableViewManager.tableView(tableViewManager.tableView, estimatedHeightForRowAt: indexPath)
-        expect(height) == 20.0
+        height = delegate.tableView(tableViewManager.tableView, estimatedHeightForRowAt: indexPath)
+        expect(height).to(equal(20.0))
     }
 
     func testHeightForRowAtIndexPath() {
@@ -168,37 +169,37 @@ class TableViewDelegateTests: XCTestCase {
         var indexPath: IndexPath
 
         indexPath = IndexPath(row: 0, section: 0)
-        height = tableViewManager.tableView(tableViewManager.tableView, heightForRowAt: indexPath)
-        expect(height) == UITableViewAutomaticDimension
+        height = delegate.tableView(tableViewManager.tableView, heightForRowAt: indexPath)
+        expect(height).to(equal(UITableViewAutomaticDimension))
 
         indexPath = IndexPath(row: 0, section: 1)
-        height = tableViewManager.tableView(tableViewManager.tableView, heightForRowAt: indexPath)
-        expect(height) == tableViewManager.tableView.rowHeight
+        height = delegate.tableView(tableViewManager.tableView, heightForRowAt: indexPath)
+        expect(height).to(equal(tableViewManager.tableView.rowHeight))
 
         indexPath = IndexPath(row: 1, section: 1)
-        height = tableViewManager.tableView(tableViewManager.tableView, heightForRowAt: indexPath)
-        expect(height) == StaticHeigthItem.testStaticHeightValue
+        height = delegate.tableView(tableViewManager.tableView, heightForRowAt: indexPath)
+        expect(height).to(equal(StaticHeigthItem.testStaticHeightValue))
     }
 
     func testSelectRow() {
         var indexPath: IndexPath
 
         indexPath = IndexPath(row: 0, section: 0)
-        tableViewManager.tableView(tableViewManager.tableView, didSelectRowAt: indexPath)
+        delegate.tableView(tableViewManager.tableView, didSelectRowAt: indexPath)
 
         let section = tableViewManager.sections[0]
         indexPath = IndexPath(row: section.items.count, section: 0)
         let item = SelectableItem()
         section.items.append(item)
 
-        tableViewManager.tableView(tableViewManager.tableView, didSelectRowAt: indexPath)
-        expect(item.check) == 1
+        delegate.tableView(tableViewManager.tableView, didSelectRowAt: indexPath)
+        expect(item.check).to(equal(1))
 
         item.select(in: tableViewManager, animated: true)
-        expect(item.check) == 2
+        expect(item.check).to(equal(2))
 
         item.deselect(in: tableViewManager, animated: true)
-        expect(item.check) == 2
+        expect(item.check).to(equal(2))
     }
 
     func testEditableRows() {
@@ -210,13 +211,27 @@ class TableViewDelegateTests: XCTestCase {
         editableItem.actions = [deleteAction]
         section.items.append(editableItem)
 
-        let sectionIndex = section.index(in: tableViewManager)!
-        let rows = tableViewManager.tableView(tableViewManager.tableView, numberOfRowsInSection: sectionIndex)
-        XCTAssert(rows == 2)
-
         let indexPath = editableItem.indexPath(in: tableViewManager)!
-        let actions = tableViewManager.tableView(tableViewManager.tableView, editActionsForRowAt: indexPath)
+        let actions = delegate.tableView(tableViewManager.tableView, editActionsForRowAt: indexPath)
         XCTAssertNotNil(actions)
         XCTAssert(actions!.count == 1)
     }
+
+	func testViewForHeaderInSection() {
+		let view = delegate.tableView(self.tableViewManager.tableView, viewForHeaderInSection: 0)
+		expect(view).to(beNil())
+	}
+
+	func testViewForFooterInSection() {
+		var view: UIView?
+		view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 0)
+		expect(view).to(beNil())
+
+		view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 1)
+		expect(view).to(beNil())
+
+		view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 2)
+		expect(view).toNot(beNil())
+
+	}
 }

--- a/TableViewKitTests/TableViewDelegateTests.swift
+++ b/TableViewKitTests/TableViewDelegateTests.swift
@@ -90,7 +90,7 @@ class EditableItem: SelectableItem, Editable {
 class TableViewDelegateTests: XCTestCase {
 
     fileprivate var tableViewManager: TableViewManager!
-	fileprivate var delegate: TableViewKitDelegate { return tableViewManager.tableView.delegate as! TableViewKitDelegate }
+	fileprivate var delegate: TableViewKitDelegate { return tableViewManager.delegate as! TableViewKitDelegate }
 
     override func setUp() {
         super.setUp()

--- a/TableViewKitTests/TableViewDelegateTests.swift
+++ b/TableViewKitTests/TableViewDelegateTests.swift
@@ -111,40 +111,40 @@ class TableViewDelegateTests: XCTestCase {
         var height: CGFloat
 
         height = delegate.tableView(tableViewManager.tableView, estimatedHeightForHeaderInSection: 0)
-        expect(height).to(beGreaterThan(0.0))
+        expect(height) > 0.0
 
         height = delegate.tableView(tableViewManager.tableView, estimatedHeightForHeaderInSection: 1)
-        expect(height).to(equal(tableViewManager.tableView.estimatedSectionHeaderHeight))
+        expect(height) == tableViewManager.tableView.estimatedSectionHeaderHeight
     }
 
     func testHeightForHeader() {
         var height: CGFloat
 
         height = delegate.tableView(tableViewManager.tableView, heightForHeaderInSection: 0)
-        expect(height).to(equal(UITableViewAutomaticDimension))
+        expect(height) == UITableViewAutomaticDimension
     }
 
     func testEstimatedHeightForFooter() {
         var height: CGFloat
 
         height = delegate.tableView(tableViewManager.tableView, estimatedHeightForFooterInSection: 0)
-        expect(height).to(beGreaterThan(0.0))
+        expect(height) > 0.0
 
         height = delegate.tableView(tableViewManager.tableView, estimatedHeightForFooterInSection: 1)
-        expect(height).to(equal(tableViewManager.tableView.estimatedSectionFooterHeight))
+        expect(height) == tableViewManager.tableView.estimatedSectionFooterHeight
 
         height = delegate.tableView(tableViewManager.tableView, estimatedHeightForFooterInSection: 2)
-        expect(height).to(equal(44.0))
+        expect(height) == 44.0
     }
 
     func testHeightForFooter() {
         var height: CGFloat
 
         height = delegate.tableView(tableViewManager.tableView, heightForFooterInSection: 0)
-        expect(height).to(equal(UITableViewAutomaticDimension))
+        expect(height) == UITableViewAutomaticDimension
 
         height = delegate.tableView(tableViewManager.tableView, heightForFooterInSection: 2)
-        expect(height).to(equal(UITableViewAutomaticDimension))
+        expect(height) == UITableViewAutomaticDimension
     }
 
     func testEstimatedHeightForRowAtIndexPath() {
@@ -153,15 +153,15 @@ class TableViewDelegateTests: XCTestCase {
 
         indexPath = IndexPath(row: 0, section: 0)
         height = delegate.tableView(tableViewManager.tableView, estimatedHeightForRowAt: indexPath)
-        expect(height).to(equal(44.0))
+        expect(height) == 44.0
 
         indexPath = IndexPath(row: 0, section: 1)
         height = delegate.tableView(tableViewManager.tableView, estimatedHeightForRowAt: indexPath)
-        expect(height).to(equal(tableViewManager.tableView.estimatedRowHeight))
+        expect(height) == tableViewManager.tableView.estimatedRowHeight
 
         indexPath = IndexPath(row: 1, section: 1)
         height = delegate.tableView(tableViewManager.tableView, estimatedHeightForRowAt: indexPath)
-        expect(height).to(equal(20.0))
+        expect(height) == 20.0
     }
 
     func testHeightForRowAtIndexPath() {
@@ -170,15 +170,15 @@ class TableViewDelegateTests: XCTestCase {
 
         indexPath = IndexPath(row: 0, section: 0)
         height = delegate.tableView(tableViewManager.tableView, heightForRowAt: indexPath)
-        expect(height).to(equal(UITableViewAutomaticDimension))
+        expect(height) == UITableViewAutomaticDimension
 
         indexPath = IndexPath(row: 0, section: 1)
         height = delegate.tableView(tableViewManager.tableView, heightForRowAt: indexPath)
-        expect(height).to(equal(tableViewManager.tableView.rowHeight))
+        expect(height) == tableViewManager.tableView.rowHeight
 
         indexPath = IndexPath(row: 1, section: 1)
         height = delegate.tableView(tableViewManager.tableView, heightForRowAt: indexPath)
-        expect(height).to(equal(StaticHeigthItem.testStaticHeightValue))
+        expect(height) == StaticHeigthItem.testStaticHeightValue
     }
 
     func testSelectRow() {
@@ -193,13 +193,13 @@ class TableViewDelegateTests: XCTestCase {
         section.items.append(item)
 
         delegate.tableView(tableViewManager.tableView, didSelectRowAt: indexPath)
-        expect(item.check).to(equal(1))
+        expect(item.check) == 1
 
         item.select(in: tableViewManager, animated: true)
-        expect(item.check).to(equal(2))
+        expect(item.check) == 2
 
         item.deselect(in: tableViewManager, animated: true)
-        expect(item.check).to(equal(2))
+        expect(item.check) == 2
     }
 
     func testEditableRows() {
@@ -226,12 +226,12 @@ class TableViewDelegateTests: XCTestCase {
         var view: UIView?
         view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 0)
         expect(view).to(beNil())
-        
+
         view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 1)
         expect(view).to(beNil())
-        
+
         view = delegate.tableView(self.tableViewManager.tableView, viewForFooterInSection: 2)
         expect(view).toNot(beNil())
-        
+
     }
 }

--- a/TableViewKitTests/TableViewDelegateTests.swift
+++ b/TableViewKitTests/TableViewDelegateTests.swift
@@ -90,7 +90,7 @@ class EditableItem: SelectableItem, Editable {
 class TableViewDelegateTests: XCTestCase {
 
     fileprivate var tableViewManager: TableViewManager!
-    fileprivate var delegate: TableViewKitDelegate { return tableViewManager.delegate as! TableViewKitDelegate }
+    fileprivate var delegate: TableViewKitDelegate { return tableViewManager.delegate! }
 
     override func setUp() {
         super.setUp()

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -170,7 +170,7 @@ class TableViewKitTests: XCTestCase {
         let tableViewManager = TableViewManager(tableView: UITableView(), sections: [section])
 
         guard let indexPath = item.indexPath(in: tableViewManager) else { return }
-		let dataSource = tableViewManager.tableView.dataSource as! TableViewKitDataSource
+		let dataSource = tableViewManager.dataSource!
         var cell = dataSource.tableView(tableViewManager.tableView, cellForRowAt: indexPath)
 
         expect(cell.textLabel?.text) == item.title

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -170,14 +170,15 @@ class TableViewKitTests: XCTestCase {
         let tableViewManager = TableViewManager(tableView: UITableView(), sections: [section])
 
         guard let indexPath = item.indexPath(in: tableViewManager) else { return }
-        var cell = tableViewManager.tableView(tableViewManager.tableView, cellForRowAt: indexPath)
+		let dataSource = tableViewManager.tableView.dataSource as! TableViewKitDataSource
+        var cell = dataSource.tableView(tableViewManager.tableView, cellForRowAt: indexPath)
 
         expect(cell.textLabel?.text) == item.title
 
         item.title = "After"
         item.reload(in: tableViewManager)
 
-        cell = tableViewManager.tableView(tableViewManager.tableView, cellForRowAt: indexPath)
+        cell = dataSource.tableView(tableViewManager.tableView, cellForRowAt: indexPath)
 
         expect(cell.textLabel?.text) == item.title
     }


### PR DESCRIPTION
This PR contains a breaking change: it extracts `UITableViewDataSource` and `UITableViewDelegate` from `TableViewManager`. It's needed for future implementation such as compatibility for `UICollectionView`.

It also add support for `UIScrollViewDelegate` from `TableViewManager` via `scrollDelegate`