### PR TITLE
Add support for TableViewKit as a property for Item and Section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+---
+
+## [Unreleased]
+### Added
+- Support `TableViewManager` as `manager` property of `Item` and `Section`

--- a/TableViewKit/Protocols/Item.swift
+++ b/TableViewKit/Protocols/Item.swift
@@ -20,6 +20,20 @@ public extension Item where Self: Equatable {
     }
 }
 
+private var ItemTableViewManagerKey: UInt8 = 0
+
+extension Item {
+
+    public internal(set) var manager: TableViewManager? {
+        get {
+            return objc_getAssociatedObject(self, &ItemTableViewManagerKey) as? TableViewManager
+        }
+        set(newValue) {
+            objc_setAssociatedObject(self, &ItemTableViewManagerKey, newValue as AnyObject, objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN)
+        }
+    }
+}
+
 extension Item {
 
     public func equals(_ other: Any?) -> Bool {

--- a/TableViewKit/Protocols/Item.swift
+++ b/TableViewKit/Protocols/Item.swift
@@ -20,6 +20,7 @@ public extension Item where Self: Equatable {
     }
 }
 
+// swiftlint:disable:next identifier_name
 private var ItemTableViewManagerKey: UInt8 = 0
 
 extension Item {
@@ -29,7 +30,10 @@ extension Item {
             return objc_getAssociatedObject(self, &ItemTableViewManagerKey) as? TableViewManager
         }
         set(newValue) {
-            objc_setAssociatedObject(self, &ItemTableViewManagerKey, newValue as AnyObject, objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN)
+            objc_setAssociatedObject(self,
+                                     &ItemTableViewManagerKey,
+                                     newValue as AnyObject,
+                                     objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN)
         }
     }
 }

--- a/TableViewKit/Section.swift
+++ b/TableViewKit/Section.swift
@@ -35,6 +35,7 @@ extension Section {
     public var footer: HeaderFooterView { return nil }
 }
 
+// swiftlint:disable:next identifier_name
 private var SectionTableViewManagerKey: UInt8 = 0
 
 extension Section {
@@ -44,7 +45,10 @@ extension Section {
             return objc_getAssociatedObject(self, &SectionTableViewManagerKey) as? TableViewManager
         }
         set(newValue) {
-            objc_setAssociatedObject(self, &SectionTableViewManagerKey, newValue as AnyObject, objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN)
+            objc_setAssociatedObject(self,
+                                     &SectionTableViewManagerKey,
+                                     newValue as AnyObject,
+                                     objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN)
         }
     }
 }

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -44,28 +44,23 @@ open class TableViewManager: NSObject {
     }
 
     private func setupSections() {
-        sections.forEach { section in
-            section.setup(in: self)
-            section.register(in: self)
-        }
+        sections.forEach { $0.register(in: self) }
         sections.callback = { [weak self] in self?.onSectionsUpdate(withChanges: $0) }
     }
 
-    private func onSectionsUpdate(withChanges changes: ArrayChanges) {
+    private func onSectionsUpdate(withChanges changes: ArrayChanges<Section>) {
         switch changes {
-        case .inserts(let array):
-            array.forEach { index in
-                sections[index].setup(in: self)
-                sections[index].register(in: self)
-            }
-            tableView.insertSections(IndexSet(array), with: animation)
-        case .deletes(let array):
-            tableView.deleteSections(IndexSet(array), with: animation)
-        case .updates(let array):
-            tableView.reloadSections(IndexSet(array), with: animation)
-        case .moves(let array):
-            let fromIndex = array.map { $0.0 }
-            let toIndex = array.map { $0.1 }
+        case .inserts(let indexes, let insertedSections):
+            insertedSections.forEach { $0.register(in: self) }
+            tableView.insertSections(IndexSet(indexes), with: animation)
+        case .deletes(let indexes, let removedSections):
+            removedSections.forEach { $0.unregister() }
+            tableView.deleteSections(IndexSet(indexes), with: animation)
+        case .updates(let indexes):
+            tableView.reloadSections(IndexSet(indexes), with: animation)
+        case .moves(let indexes):
+            let fromIndex = indexes.map { $0.0 }
+            let toIndex = indexes.map { $0.1 }
             tableView.moveSections(from: fromIndex, to: toIndex)
         case .beginUpdates:
             if animation == .none {

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -296,4 +296,25 @@ class TableViewKitTests: XCTestCase {
         let registerItem = section.items.first as? TestReloadItem
         XCTAssert(registerItem?.title == "Register")
     }
+
+    func testManagerProperty() {
+        let tableView = UITableView()
+
+        let item1 = TestItem()
+        XCTAssertNil(item1.manager)
+        let section = NoHeaderFooterSection(items: [item1])
+        XCTAssertNil(section.manager)
+
+        let tableViewManager = TableViewManager(tableView: tableView, sections: [section])
+        XCTAssert(item1.manager == tableViewManager)
+        XCTAssert(section.manager == tableViewManager)
+
+        let section2 = NoHeaderFooterSection(items: [item1])
+        tableViewManager.sections.append(section2)
+        XCTAssert(section2.manager == tableViewManager)
+
+        let item2 = TestItem()
+        section.items.append(item2)
+        XCTAssert(item2.manager == tableViewManager)
+    }
 }

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -316,5 +316,12 @@ class TableViewKitTests: XCTestCase {
         let item2 = TestItem()
         section.items.append(item2)
         XCTAssert(item2.manager == tableViewManager)
+
+        let removedSection = tableViewManager.sections.removeFirst()
+
+        XCTAssert(removedSection === section)
+        XCTAssertNil(removedSection.manager)
+        XCTAssertNil(removedSection.items[0].manager)
+
     }
 }

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -307,16 +307,16 @@ class TableViewKitTests: XCTestCase {
         XCTAssertNil(section.manager)
 
         let tableViewManager = TableViewManager(tableView: tableView, sections: [section])
-        XCTAssert(item1.manager == tableViewManager)
-        XCTAssert(section.manager == tableViewManager)
+        XCTAssert(item1.manager === tableViewManager)
+        XCTAssert(section.manager === tableViewManager)
 
         let section2 = NoHeaderFooterSection(items: [item1])
         tableViewManager.sections.append(section2)
-        XCTAssert(section2.manager == tableViewManager)
+        XCTAssert(section2.manager === tableViewManager)
 
         let item2 = TestItem()
         section.items.append(item2)
-        XCTAssert(item2.manager == tableViewManager)
+        XCTAssert(item2.manager === tableViewManager)
 
         let removedSection = tableViewManager.sections.removeFirst()
 


### PR DESCRIPTION
This is an additive change.
A property `managed` has been added to `Item` and `Section`, which is automatically set and reset by the framework.
It may enable a future PR to simplify and remove the parameter `manager` of several methods.