### PR TITLE
Simplified Item and Sections methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Move `UITableViewDataSource` and `UITableViewDelegate` implementations from `TableViewManager` to `TableViewKitDataSource` and `TableViewKitDelegate` which are now the properties: `dataSource` and `delegate`, respectively.
+- Method `Item.section(in:)` has been renamed to `Item.section`
+- Method `Item.indexPath(in:)` has been renamed to `Item.indexPath`
+- Method `Item.reload(in:with:)` has been renamed to `Item.reload(with:)`
+- Method `Item.select(in:animated:scrollPosition:)` has been renamed to `Item.select(animated:scrollPosition:)`
+- Method `Item.select(in:animated:scrollPosition:)` has been renamed to `Item.select(animated:scrollPosition:)`
+- Method `Item.deselect(in:animated:)` has been renamed to `Item.deselect(animated:)`
+- Method `Section.index(in:)` has been renamed to `Section.index`
+

--- a/Examples/SampleApp/SampleApp/ActionBar/ActionBarManager.swift
+++ b/Examples/SampleApp/SampleApp/ActionBar/ActionBarManager.swift
@@ -22,7 +22,7 @@ class ActionBarManager: ActionBarDelegate {
 
         func isFirstResponder(item: Item) -> Bool {
             if isResponder(item: item),
-                let indexPath = item.indexPath(in: manager),
+                let indexPath = item.indexPath,
                 manager.tableView.cellForRow(at: indexPath)?.isFirstResponder == true {
                 return true
             }
@@ -47,7 +47,7 @@ class ActionBarManager: ActionBarDelegate {
             item = array.prefix(upTo: index).reversed().first(where: isResponder)
         }
 
-        return item?.indexPath(in: manager)
+        return item?.indexPath
 
     }
 }

--- a/Examples/SampleApp/SampleApp/Example1.swift
+++ b/Examples/SampleApp/SampleApp/Example1.swift
@@ -42,17 +42,17 @@ class Example1: UIViewController, TableViewManagerCompatible {
             textFieldItem2.validation.add(rule: ExistRule())
 
             item.onSelection = { item in
-                item.deselect(in: self.vc.tableViewManager, animated: true)
+                item.deselect(animated: true)
                 self.vc.showPickerControl()
             }
             dateItem.accessoryType = .disclosureIndicator
             dateItem.onSelection = { item in
-                item.deselect(in: self.vc.tableViewManager, animated: true)
+                item.deselect(animated: true)
                 self.vc.showDatePickerControl()
             }
             selectionItem.accessoryType = .disclosureIndicator
             selectionItem.onSelection = { item in
-                item.deselect(in: self.vc.tableViewManager, animated: true)
+                item.deselect(animated: true)
                 self.vc.showPickerControl()
             }
             states[State.preParty] = [item, dateItem, selectionItem, textFieldItem, textFieldItem2]
@@ -82,7 +82,7 @@ class Example1: UIViewController, TableViewManagerCompatible {
                 } else {
                     let item = CustomItem(title: "Label  \(index)")
                     item.onSelection = { item in
-                        item.deselect(in: self.vc.tableViewManager, animated: true)
+                        item.deselect(animated: true)
                     }
                     return item
                 }
@@ -117,7 +117,7 @@ class Example1: UIViewController, TableViewManagerCompatible {
                     default:
                         self.transition(to: .all)
                     }
-                    item.deselect(in: self.vc.tableViewManager, animated: true)
+                    item.deselect(animated: true)
                 }
                 return item
             }

--- a/Examples/SampleApp/SampleApp/SelectionViewController.swift
+++ b/Examples/SampleApp/SampleApp/SelectionViewController.swift
@@ -125,13 +125,13 @@ public class SelectionViewController: UITableViewController {
             if let checkedItem = itemSelected() {
                 checkedItem.selected = false
                 checkedItem.accessoryType = .none
-                checkedItem.reload(in: tableViewManager, with: .fade)
+                checkedItem.reload(with: .fade)
             }
         }
 
         item.selected = !item.selected
         item.accessoryType = item.accessoryType == .checkmark ? .none : .checkmark
-        item.reload(in: tableViewManager, with: .fade)
+        item.reload(with: .fade)
 
         fillSelected()
     }

--- a/Examples/SampleApp/SampleApp/ViewController.swift
+++ b/Examples/SampleApp/SampleApp/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController, TableViewManagerCompatible {
                 let item = CustomItem(title: "Example 1")
                 item.onSelection = { _ in
                     self.vc.present(navigationController, animated: true, completion: {
-                        item.deselect(in: self.vc.tableViewManager, animated: false)
+                        item.deselect(animated: false)
                     })
                 }
                 return item

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutItem.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutItem.swift
@@ -58,8 +58,6 @@ class MoreAboutItem: Item, Selectable, Editable {
             presenter?.showRateApp()
         }
 
-        if let manager = manager {
-            deselect(in: manager, animated: true)
-        }
+        deselect(animated: true)
     }
 }

--- a/TableViewKit/Protocols/Item.swift
+++ b/TableViewKit/Protocols/Item.swift
@@ -52,41 +52,37 @@ extension Item {
         return .dynamic(44.0)
     }
 
-    /// Returns the `section` of the `item` in the specified `manager`
-    ///
-    /// - parameter manager: A `manager` where the `item` may have been added
+    /// Returns the `section` of the `item`
     ///
     /// - returns: The `section` of the `item` or `nil` if not present
-    public func section(in manager: TableViewManager) -> Section? {
-        guard let indexPath = self.indexPath(in: manager) else { return nil }
-        return manager.sections[indexPath.section]
+    public var section: Section? {
+        guard let indexPath = indexPath else { return nil }
+        return manager?.sections[indexPath.section]
     }
 
-    /// Returns the `indexPath` of the `item` in the specified `manager`
-    ///
-    /// - parameter manager: A `manager` where the `item` may have been added
+    /// Returns the `indexPath` of the `item`
     ///
     /// - returns: The `indexPath` of the `item` or `nil` if not present
-    public func indexPath(in manager: TableViewManager) -> IndexPath? {
+    public var indexPath: IndexPath? {
+        guard let manager = manager else { return nil }
         for section in manager.sections {
             guard
-                let sectionIndex = section.index(in: manager),
+                let sectionIndex = section.index,
                 let rowIndex = section.items.index(of: self) else { continue }
             return IndexPath(row: rowIndex, section: sectionIndex)
         }
         return nil
     }
 
-    /// Reload the `item` in the specified `manager` with an `animation`
+    /// Reload the `item` with an `animation`
     ///
-    /// - parameter manager: A `manager` where the `item` may have been added
     /// - parameter animation: A constant that indicates how the reloading is to be animated
     ///
     /// - returns: The `section` of the `item` or `nil` if not present
-    public func reload(in manager: TableViewManager, with animation: UITableViewRowAnimation = .automatic) {
-        guard let indexPath = self.indexPath(in: manager) else { return }
-        let section = manager.sections[indexPath.section]
-        section.items.callback?(.updates([indexPath.row]))
+    public func reload(with animation: UITableViewRowAnimation = .automatic) {
+        guard let indexPath = indexPath else { return }
+        let section = manager?.sections[indexPath.section]
+        section?.items.callback?(.updates([indexPath.row]))
     }
 
 }

--- a/TableViewKit/Protocols/Selectable.swift
+++ b/TableViewKit/Protocols/Selectable.swift
@@ -11,23 +11,26 @@ extension Selectable {
 
     /// Select the `item`
     ///
-    /// - parameter manager: A `manager` where the `item` may have been added
     /// - parameter animated:       If the selection should be animated
     /// - parameter scrollPosition: The scrolling position
     // swiftlint:disable:next line_length
-    public func select(in manager: TableViewManager, animated: Bool, scrollPosition: UITableViewScrollPosition = .none) {
+    public func select(animated: Bool, scrollPosition: UITableViewScrollPosition = .none) {
+        guard let tableView = manager?.tableView else { return }
 
-        manager.tableView.selectRow(at: indexPath(in: manager), animated: animated, scrollPosition: scrollPosition)
-        manager.tableView.delegate?.tableView?(manager.tableView, didSelectRowAt: indexPath(in: manager)!)
+        tableView.selectRow(at: indexPath, animated: animated, scrollPosition: scrollPosition)
+        if let indexPath = indexPath {
+            tableView.delegate?.tableView?(tableView, didSelectRowAt: indexPath)
+        }
     }
 
     /// Deselect the `item`
     ///
-    /// - parameter manager: A `manager` where the `item` may have been added
     /// - parameter animated:       If the selection should be animated
-    public func deselect(in manager: TableViewManager, animated: Bool) {
-        if let indexPath = indexPath(in: manager) {
-            manager.tableView.deselectRow(at: indexPath, animated: animated)
+    public func deselect(animated: Bool) {
+        guard let tableView = manager?.tableView else { return }
+
+        if let indexPath = indexPath {
+            tableView.deselectRow(at: indexPath, animated: animated)
         }
     }
 

--- a/TableViewKit/Section.swift
+++ b/TableViewKit/Section.swift
@@ -14,7 +14,7 @@ public protocol Section: class, AnyEquatable {
     /// The `footer` of the section, none if not defined
     var footer: HeaderFooterView { get }
 
-    func index(in manager: TableViewManager) -> Int?
+    var index: Int? { get }
 }
 
 public extension Section where Self: Equatable {
@@ -62,13 +62,11 @@ extension Section {
         return false
     }
 
-    /// Returns the `index` of the `section` in the specified `manager`
-    ///
-    /// - parameter manager: A `manager` where the `section` may have been added
+    /// Returns the `index` of the `section`
     ///
     /// - returns: The `index` of the `section` or `nil` if not present
-    public func index(in manager: TableViewManager) -> Int? {
-        return manager.sections.index(of: self)
+    public var index: Int? {
+        return manager?.sections.index(of: self)
     }
 
     /// Register the section in the specified manager
@@ -110,7 +108,7 @@ extension Section {
 
     private func onItemsUpdate(withChanges changes: ArrayChanges<Item>, in manager: TableViewManager) {
 
-        guard let sectionIndex = index(in: manager) else { return }
+        guard let sectionIndex = index else { return }
         let tableView = manager.tableView
 
         if case .inserts(_, let items) = changes {

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -95,7 +95,7 @@ class TableViewDataSourceTests: XCTestCase {
         let otherItem = DifferentItem()
         section.items.append(otherItem)
 
-        let indexPath = otherItem.indexPath(in: tableViewManager)!
+        let indexPath = otherItem.indexPath!
         let drawer = type(of: otherItem).drawer
         let cell = drawer.cell(in: tableViewManager, with: otherItem as Item, for: indexPath)
 

--- a/TableViewKitTests/TableViewDelegateTests.swift
+++ b/TableViewKitTests/TableViewDelegateTests.swift
@@ -195,10 +195,10 @@ class TableViewDelegateTests: XCTestCase {
         delegate.tableView(tableViewManager.tableView, didSelectRowAt: indexPath)
         expect(item.check) == 1
 
-        item.select(in: tableViewManager, animated: true)
+        item.select(animated: true)
         expect(item.check) == 2
 
-        item.deselect(in: tableViewManager, animated: true)
+        item.deselect(animated: true)
         expect(item.check) == 2
     }
 
@@ -211,7 +211,7 @@ class TableViewDelegateTests: XCTestCase {
         editableItem.actions = [deleteAction]
         section.items.append(editableItem)
 
-        let indexPath = editableItem.indexPath(in: tableViewManager)!
+        let indexPath = editableItem.indexPath!
         let actions = delegate.tableView(tableViewManager.tableView, editActionsForRowAt: indexPath)
         XCTAssertNotNil(actions)
         XCTAssert(actions!.count == 1)


### PR DESCRIPTION
This contains breaking changes, few methods have been renamed.
Since it will be released in a major version, no deprecated warnings have been added.

`Item.section(in:)` has been renamed to `Item.section`
`Item.indexPath(in:)` has been renamed to `Item.indexPath`
`Item.reload(in:with:)` has been renamed to `Item.reload(with:)`
`Item.select(in:animated:scrollPosition:)` has been renamed to `Item.select(animated:scrollPosition:)`
`Item.select(in:animated:scrollPosition:)` has been renamed to `Item.select(animated:scrollPosition:)`
`Item.deselect(in:animated:)` has been renamed to `Item.deselect(animated:)`
`Section.index(in:)` has been renamed to `Section.index`