### PR TITLE
Rename Item and Section to TableItem and TableSection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support for item's `copy` and `paste` action via `ActionPerformable`
 ### Changed
+- Deprecated `Item` in favour of `TableItem`
+- Deprecated `Section` in favour of `TableSection`
 - Optimize diff algorithm used by `ObservableArray` for common methods such as `insert(at:)`, `remove(at:)` etc...
 - Fix a bug where `manager` was not set correctly on `Item` or `Section`
 - Fix memory ownership of `ObservableArray` for Swift 4

--- a/Examples/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/Examples/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -236,7 +236,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = ODIGEO;
 				TargetAttributes = {
 					257F72C01D07204A00F7B954 = {
@@ -299,13 +299,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SampleApp-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		6AF3F1B07CA3D96A8145F9B2 /* [CP] Copy Pods Resources */ = {
@@ -329,9 +332,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/TableViewKit/TableViewKit.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TableViewKit.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -408,14 +414,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -455,14 +467,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;

--- a/Examples/SampleApp/SampleApp.xcodeproj/xcshareddata/xcschemes/SampleApp.xcscheme
+++ b/Examples/SampleApp/SampleApp.xcodeproj/xcshareddata/xcschemes/SampleApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -55,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Examples/SampleApp/SampleApp/ActionBar/ActionBarManager.swift
+++ b/Examples/SampleApp/SampleApp/ActionBar/ActionBarManager.swift
@@ -20,7 +20,7 @@ class ActionBarManager: ActionBarDelegate {
 
     fileprivate func indexPathForResponder(forDirection direction: Direction) -> IndexPath? {
 
-        func isFirstResponder(item: Item) -> Bool {
+        func isFirstResponder(item: TableItem) -> Bool {
             if isResponder(item: item),
                 let indexPath = item.indexPath,
                 manager.tableView.cellForRow(at: indexPath)?.isFirstResponder == true {
@@ -29,7 +29,7 @@ class ActionBarManager: ActionBarDelegate {
             return false
         }
 
-        func isResponder(item: Item) -> Bool {
+        func isResponder(item: TableItem) -> Bool {
             return (item as? UIResponder)?.canBecomeFirstResponder ?? false
         }
 
@@ -38,7 +38,7 @@ class ActionBarManager: ActionBarDelegate {
             let index = array.index(of: currentItem)
             else { return nil }
 
-        let item: Item?
+        let item: TableItem?
 
         switch direction {
         case .next:

--- a/Examples/SampleApp/SampleApp/CustomItem.swift
+++ b/Examples/SampleApp/SampleApp/CustomItem.swift
@@ -13,7 +13,7 @@ public class CustomDrawer: CellDrawer {
     }
 }
 
-public class CustomItem: Selectable, Item {
+public class CustomItem: Selectable, TableItem {
     public static var drawer = AnyCellDrawer(CustomDrawer.self)
 
     public var title: String?

--- a/Examples/SampleApp/SampleApp/Example1.swift
+++ b/Examples/SampleApp/SampleApp/Example1.swift
@@ -11,9 +11,9 @@ protocol ActionManagerCompatible {
 }
 
 class Example1: UIViewController, TableViewManagerCompatible {
-    fileprivate class FirstSection: Section, StaticStateful {
-        var items: ObservableArray<Item> = []
-        var states: [State: [Item]] = [:]
+    fileprivate class FirstSection: TableSection, StaticStateful {
+        var items: ObservableArray<TableItem> = []
+        var states: [State: [TableItem]] = [:]
 
         enum State: Int {
             case preParty
@@ -63,9 +63,9 @@ class Example1: UIViewController, TableViewManagerCompatible {
 
     }
 
-    fileprivate class SecondSection: Section {
+    fileprivate class SecondSection: TableSection {
 
-        var items: ObservableArray<Item> = []
+        var items: ObservableArray<TableItem> = []
 
         internal var header: HeaderFooterView = .view(CustomHeaderItem(title: "Second Section"))
 
@@ -75,7 +75,7 @@ class Example1: UIViewController, TableViewManagerCompatible {
             self.vc = vc
 
             let total: [Int] = Array(1...100)
-            let items = total.map({ (index) -> Item in
+            let items = total.map({ (index) -> TableItem in
                 if (index % 2 == 0) {
                     let item = TextFieldItem(placeHolder: "Textfield \(index)", actionBarDelegate: vc.actionBarManager)
                     return item
@@ -91,15 +91,15 @@ class Example1: UIViewController, TableViewManagerCompatible {
         }
     }
 
-    fileprivate class ThirdSection: Section, Stateful {
+    fileprivate class ThirdSection: TableSection, Stateful {
 
         enum State {
             case all
-            case selected(Item)
+            case selected(TableItem)
         }
 
-        var items: ObservableArray<Item> = []
-        var allItems: [Item] = []
+        var items: ObservableArray<TableItem> = []
+        var allItems: [TableItem] = []
         var currentState: State = .all
 
         let vc: TableViewManagerCompatible
@@ -108,7 +108,7 @@ class Example1: UIViewController, TableViewManagerCompatible {
             self.vc = vc
 
             let total: [Int] = Array(1...10)
-            self.allItems = total.map { (index) -> Item in
+            self.allItems = total.map { (index) -> TableItem in
                 let item = CustomItem(title: "Label  \(index)")
                 item.onSelection = { item in
                     switch self.currentState {
@@ -124,7 +124,7 @@ class Example1: UIViewController, TableViewManagerCompatible {
             self.transition(to: currentState)
         }
 
-        func items(for state: State) -> [Item] {
+        func items(for state: State) -> [TableItem] {
             switch state {
             case .all:
                 return allItems

--- a/Examples/SampleApp/SampleApp/SelectionViewController.swift
+++ b/Examples/SampleApp/SampleApp/SelectionViewController.swift
@@ -2,14 +2,14 @@ import Foundation
 import UIKit
 import TableViewKit
 
-class SelectionSection: Section {
-    var items: ObservableArray<Item> = []
+class SelectionSection: TableSection {
+    var items: ObservableArray<TableItem> = []
     weak var tableViewManager: TableViewManager!
 
     required init() { }
 }
 
-public protocol SelectionItemProtocol: Item {
+public protocol SelectionItemProtocol: TableItem {
 
     var value: Any { get }
     var selected: Bool { get set }

--- a/Examples/SampleApp/SampleApp/TextFieldItem.swift
+++ b/Examples/SampleApp/SampleApp/TextFieldItem.swift
@@ -3,7 +3,7 @@ import TableViewKit
 
 public class TextFieldCell: UITableViewCell, ItemCompatible, ActionBarDelegate {
 
-    public var item: Item?
+    public var item: TableItem?
 
     public var textFieldItem: TextFieldItem {
         get {
@@ -58,7 +58,7 @@ public class TextFieldDrawer: CellDrawer {
     }
 }
 
-public class TextFieldItem: UIResponder, Item, ContentValidatable, Validationable {
+public class TextFieldItem: UIResponder, TableItem, ContentValidatable, Validationable {
 
     public static var drawer = AnyCellDrawer(TextFieldDrawer.self)
 

--- a/Examples/SampleApp/SampleApp/ViewController.swift
+++ b/Examples/SampleApp/SampleApp/ViewController.swift
@@ -3,8 +3,8 @@ import TableViewKit
 
 class ViewController: UIViewController, TableViewManagerCompatible {
 
-    fileprivate class CustomSection: Section {
-        var items: ObservableArray<Item>
+    fileprivate class CustomSection: TableSection {
+        var items: ObservableArray<TableItem>
 
         let vc: ViewController
 
@@ -13,7 +13,7 @@ class ViewController: UIViewController, TableViewManagerCompatible {
             self.items = []
 
             let array: [UIViewController.Type] = [Example1.self]
-            let mappedItems = array.map({ (className) -> Item in
+            let mappedItems = array.map({ (className) -> TableItem in
                 let viewController = className.init(nibName: String(describing: className), bundle: nil)
 
                 let navigationController = UINavigationController(rootViewController: viewController)

--- a/Examples/Viper/TableViewKit+VIPER.xcodeproj/project.pbxproj
+++ b/Examples/Viper/TableViewKit+VIPER.xcodeproj/project.pbxproj
@@ -180,7 +180,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "eDreams Odigeo";
 				TargetAttributes = {
 					25A741931D7ED45900473E02 = {
@@ -227,13 +227,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TableViewKit+VIPER-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		87A11139382E8ED739E3CEEC /* [CP] Embed Pods Frameworks */ = {
@@ -242,9 +245,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-TableViewKit+VIPER/Pods-TableViewKit+VIPER-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/TableViewKit/TableViewKit.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TableViewKit.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -311,14 +317,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -358,14 +370,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterCell.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterCell.swift
@@ -13,7 +13,7 @@ class HelpCenterDrawer: CellDrawer {
 
 class HelpCenterCell: UITableViewCell, ItemCompatible {
 
-    public var item: Item?
+    public var item: TableItem?
 
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var detailLabel: UILabel!

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterItem.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterItem.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TableViewKit
 
-class HelpCenterItem: Item {
+class HelpCenterItem: TableItem {
     static var drawer = AnyCellDrawer(HelpCenterDrawer.self)
 
     var height: Height? = .dynamic(44.0)

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterSection.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/HelpCenterSection.swift
@@ -1,9 +1,9 @@
 import Foundation
 import TableViewKit
 
-class HelpCenterSection: Section {
+class HelpCenterSection: TableSection {
 
-    var items: ObservableArray<Item> = []
+    var items: ObservableArray<TableItem> = []
     var header: HeaderFooterView = .title("How can we help you today?")
     let presenter: AboutPresenterProtocol?
 

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutItem.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutItem.swift
@@ -23,7 +23,7 @@ enum MoreAboutItemType {
     }
 }
 
-class MoreAboutItem: Item, Selectable, Editable {
+class MoreAboutItem: TableItem, Selectable, Editable {
     public static var drawer = AnyCellDrawer(MoreAboutDrawer.self)
 
     var type: MoreAboutItemType

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutSection.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/MoreAboutSection.swift
@@ -1,9 +1,9 @@
 import Foundation
 import TableViewKit
 
-class MoreAboutSection: Section {
+class MoreAboutSection: TableSection {
 
-    var items: ObservableArray<Item> = []
+    var items: ObservableArray<TableItem> = []
     var header: HeaderFooterView = .title("More about eDreams")
     let presenter: AboutPresenterProtocol?
     weak var manager: TableViewManager?
@@ -21,7 +21,7 @@ class MoreAboutSection: Section {
         })
 
         let types: [MoreAboutItemType] = [.faq, .contact, .terms, .feedback, .share, .rate]
-        let items: [Item] = types.map {
+        let items: [TableItem] = types.map {
             let moreAboutItem = MoreAboutItem(type: $0, presenter: presenter, manager: manager)
             moreAboutItem.actions = [deleteAction, moreAction]
             return moreAboutItem

--- a/Examples/Viper/TableViewKit+VIPER/AboutModule/OtherSection.swift
+++ b/Examples/Viper/TableViewKit+VIPER/AboutModule/OtherSection.swift
@@ -9,9 +9,9 @@
 import Foundation
 import TableViewKit
 
-class OtherSection: Section {
+class OtherSection: TableSection {
 
-    var items: ObservableArray<Item> = []
+    var items: ObservableArray<TableItem> = []
 
     init() {
         let item1 = MoreAboutItem(type: .contact, presenter: nil, manager: nil)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ TableViewKit is designed:
 
 ### Quickstart
 
-Create an `Item` with a `UITableViewCell` and `CellDrawer`. An item may have a model of the data you want to display and may control the interaction if any.
+Create an `TableItem` with a `UITableViewCell` and `CellDrawer`. An item may have a model of the data you want to display and may control the interaction if any.
 
 ```swift
 
@@ -42,7 +42,7 @@ class YourDrawer: CellDrawer {
     }
 }
 
-class YourItem: Item {
+class YourItem: TableItem {
 
     var drawer = AnyCellDrawer(YourDrawer.self)
 
@@ -52,11 +52,11 @@ class YourItem: Item {
 }
 ```
 
-Create a custom `Section` with your items.
+Create a custom `TableSection` with your items.
 
 ```swift
-class YourSection: Section {
-    var items: ObservableArray<Item>
+class YourSection: TableSection {
+    var items: ObservableArray<TableItem>
 
     var header: HeaderFooterView = .title("Your section")
 

--- a/TableViewKit.xcodeproj/project.pbxproj
+++ b/TableViewKit.xcodeproj/project.pbxproj
@@ -27,8 +27,8 @@
 		CCBE45921D72F79C00414A64 /* NSIndexSet+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBE457B1D72F79C00414A64 /* NSIndexSet+Array.swift */; };
 		CCBE45931D72F79C00414A64 /* UITableView+Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBE457C1D72F79C00414A64 /* UITableView+Register.swift */; };
 		CCBE459D1D72F79C00414A64 /* CellDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBE458A1D72F79C00414A64 /* CellDrawer.swift */; };
-		CCBE459F1D72F79C00414A64 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBE458C1D72F79C00414A64 /* Item.swift */; };
-		CCBE45A01D72F79C00414A64 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBE458D1D72F79C00414A64 /* Section.swift */; };
+		CCBE459F1D72F79C00414A64 /* TableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBE458C1D72F79C00414A64 /* TableItem.swift */; };
+		CCBE45A01D72F79C00414A64 /* TableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBE458D1D72F79C00414A64 /* TableSection.swift */; };
 		CCBE45A11D72F79C00414A64 /* TableViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBE458E1D72F79C00414A64 /* TableViewManager.swift */; };
 		CCC749411D89AAD00030F140 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCC749401D89AAD00030F140 /* Nimble.framework */; };
 		CCCAC1221D7D9E440001FC1D /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -76,8 +76,8 @@
 		CCBE457B1D72F79C00414A64 /* NSIndexSet+Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSIndexSet+Array.swift"; sourceTree = "<group>"; };
 		CCBE457C1D72F79C00414A64 /* UITableView+Register.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Register.swift"; sourceTree = "<group>"; };
 		CCBE458A1D72F79C00414A64 /* CellDrawer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CellDrawer.swift; path = Protocols/CellDrawer.swift; sourceTree = "<group>"; };
-		CCBE458C1D72F79C00414A64 /* Item.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Item.swift; path = Protocols/Item.swift; sourceTree = "<group>"; };
-		CCBE458D1D72F79C00414A64 /* Section.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
+		CCBE458C1D72F79C00414A64 /* TableItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TableItem.swift; path = Protocols/TableItem.swift; sourceTree = "<group>"; };
+		CCBE458D1D72F79C00414A64 /* TableSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableSection.swift; sourceTree = "<group>"; };
 		CCBE458E1D72F79C00414A64 /* TableViewManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewManager.swift; sourceTree = "<group>"; };
 		CCC749401D89AAD00030F140 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "External/Nimble/build/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
 		CCCAC1251D7D9EE00001FC1D /* HeaderFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HeaderFooter.swift; path = Protocols/HeaderFooter.swift; sourceTree = "<group>"; };
@@ -121,12 +121,12 @@
 		CC97D76B1D741D8E009CDF9D /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
-				CCBE458D1D72F79C00414A64 /* Section.swift */,
+				CCBE458D1D72F79C00414A64 /* TableSection.swift */,
 				CCFD05CB1D95BD3C0063A002 /* Stateful.swift */,
 				CCCAC1251D7D9EE00001FC1D /* HeaderFooter.swift */,
 				CCEF387F1D8D5A7A00F5893F /* HeaderFooterDrawer.swift */,
 				CCBE458A1D72F79C00414A64 /* CellDrawer.swift */,
-				CCBE458C1D72F79C00414A64 /* Item.swift */,
+				CCBE458C1D72F79C00414A64 /* TableItem.swift */,
 				CC97D76C1D741DC4009CDF9D /* Selectable.swift */,
 				25B0B7531DC74F6C00591467 /* Editable.swift */,
 				CC18F34E1F631BEC00D2410A /* ActionPerformable.swift */,
@@ -328,7 +328,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CCBE45A01D72F79C00414A64 /* Section.swift in Sources */,
+				CCBE45A01D72F79C00414A64 /* TableSection.swift in Sources */,
 				CC09F88B1EA791B7006FF4EA /* TableViewKitDelegate.swift in Sources */,
 				CC0DE2C81DE33B9C00E2EDE5 /* AnyEquatable.swift in Sources */,
 				CCFD05CC1D95BD3C0063A002 /* Stateful.swift in Sources */,
@@ -348,7 +348,7 @@
 				CC09F8891EA79178006FF4EA /* TableViewKitDataSource.swift in Sources */,
 				CCBE45931D72F79C00414A64 /* UITableView+Register.swift in Sources */,
 				CCBE459D1D72F79C00414A64 /* CellDrawer.swift in Sources */,
-				CCBE459F1D72F79C00414A64 /* Item.swift in Sources */,
+				CCBE459F1D72F79C00414A64 /* TableItem.swift in Sources */,
 				CCCAC1221D7D9E440001FC1D /* (null) in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TableViewKit/ActionPerformable.swift
+++ b/TableViewKit/ActionPerformable.swift
@@ -21,7 +21,7 @@ public enum ItemAction {
 }
 
 /// A type that represent an item that can perform some action like copy and paste
-public protocol ActionPerformable: Item {
+public protocol ActionPerformable: TableItem {
 
     /// Asks if the editing menu should omit the Copy or Paste command
     ///

--- a/TableViewKit/Protocols/CellDrawer.swift
+++ b/TableViewKit/Protocols/CellDrawer.swift
@@ -38,7 +38,7 @@ public extension CellDrawer {
         cell.selectionStyle = item is Selectable ? .default : .none
 
         if let cell = cell as? ItemCompatible {
-            cell.item = item as? Item
+            cell.item = item as? TableItem
         }
 
         // swiftlint:disable:next force_cast
@@ -49,8 +49,8 @@ public extension CellDrawer {
 /// A type-erased wrapper over any cell drawer
 public struct AnyCellDrawer {
     let type: CellType<UITableViewCell>
-    let cell: (TableViewManager, Item, IndexPath) -> UITableViewCell
-    let draw: (UITableViewCell, Item) -> Void
+    let cell: (TableViewManager, TableItem, IndexPath) -> UITableViewCell
+    let draw: (UITableViewCell, TableItem) -> Void
 
 	/// Creates a type-erased drawer that wraps the given cell drawer
     public init<Drawer: CellDrawer, GenericItem, Cell>(_ drawer: Drawer.Type)
@@ -62,11 +62,11 @@ public struct AnyCellDrawer {
         self.draw = { cell, item in drawer.draw(cell as! Cell, with: item as! GenericItem) }
     }
 
-	public func cell(in manager: TableViewManager, with item: Item, for indexPath: IndexPath) -> UITableViewCell {
+	public func cell(in manager: TableViewManager, with item: TableItem, for indexPath: IndexPath) -> UITableViewCell {
         return cell(manager, item, indexPath)
     }
 
-	public func draw(_ cell: UITableViewCell, with item: Item) {
+	public func draw(_ cell: UITableViewCell, with item: TableItem) {
         draw(cell, item)
     }
 

--- a/TableViewKit/Protocols/Editable.swift
+++ b/TableViewKit/Protocols/Editable.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type that represent an item that can be edited
-public protocol Editable: Item {
+public protocol Editable: TableItem {
 
     /// The associated actions
     var actions: [UITableViewRowAction]? { get set }

--- a/TableViewKit/Protocols/ItemCompatible.swift
+++ b/TableViewKit/Protocols/ItemCompatible.swift
@@ -7,5 +7,5 @@ import Foundation
 public protocol ItemCompatible: class {
 
     /// The associated item
-    var item: Item? { get set }
+    var item: TableItem? { get set }
 }

--- a/TableViewKit/Protocols/Selectable.swift
+++ b/TableViewKit/Protocols/Selectable.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type that represent an item that can be selected
-public protocol Selectable: Item {
+public protocol Selectable: TableItem {
 
     /// Method called once an item is selected by a selectRow.
     func didSelect()

--- a/TableViewKit/Protocols/Stateful.swift
+++ b/TableViewKit/Protocols/Stateful.swift
@@ -7,7 +7,7 @@ import Foundation
 /// needed to perform a transition from the `currentState` to a `newState`.
 /// You must implement `items(for:)`, that will be used to know
 /// which items belong to which `State`.
-public protocol Stateful: Section {
+public protocol Stateful: TableSection {
 
     /// A type that represent a state, such as an enum.
     associatedtype State
@@ -20,7 +20,7 @@ public protocol Stateful: Section {
     /// - parameter state: A concrete `state`
     ///
     /// - returns: The `items` belonging to a `state`
-    func items(for state: State) -> [Item]
+    func items(for state: State) -> [TableItem]
 
     /// Performs a transition from the `currentState` to a `newState`
     ///
@@ -38,12 +38,12 @@ public extension Stateful {
 public protocol StaticStateful: Stateful {
     associatedtype State: Hashable
 
-    var states: [State: [Item]] { get }
+    var states: [State: [TableItem]] { get }
 }
 
 public extension StaticStateful {
 
-    func items(for state: State) -> [Item] {
+    func items(for state: State) -> [TableItem] {
         return states[state]!
     }
 

--- a/TableViewKit/Protocols/TableItem.swift
+++ b/TableViewKit/Protocols/TableItem.swift
@@ -1,8 +1,11 @@
 import Foundation
 
+@available(*, deprecated, renamed: "TableItem")
+public typealias Item = TableItem
+
 /// A type that represent an item to be displayed
 /// defining the `drawer` and the `height`
-public protocol Item: class, AnyEquatable {
+public protocol TableItem: class, AnyEquatable {
 
     /// The `drawer` of the item
     static var drawer: AnyCellDrawer { get }
@@ -11,7 +14,7 @@ public protocol Item: class, AnyEquatable {
     var height: Height? { get }
 }
 
-public extension Item where Self: Equatable {
+public extension TableItem where Self: Equatable {
     func equals(_ other: Any?) -> Bool {
         if let other = other as? Self {
             return other == self
@@ -23,7 +26,7 @@ public extension Item where Self: Equatable {
 // swiftlint:disable:next identifier_name
 private var ItemTableViewManagerKey: UInt8 = 0
 
-extension Item {
+extension TableItem {
 
     public internal(set) var manager: TableViewManager? {
         get {
@@ -38,7 +41,7 @@ extension Item {
     }
 }
 
-extension Item {
+extension TableItem {
 
     public func equals(_ other: Any?) -> Bool {
         if let other = other as AnyObject? {
@@ -55,7 +58,7 @@ extension Item {
     /// Returns the `section` of the `item`
     ///
     /// - returns: The `section` of the `item` or `nil` if not present
-    public var section: Section? {
+    public var section: TableSection? {
         guard let indexPath = indexPath else { return nil }
         return manager?.sections[indexPath.section]
     }
@@ -87,9 +90,9 @@ extension Item {
 
 }
 
-public extension Collection where Self.Iterator.Element == Item {
+public extension Collection where Self.Iterator.Element == TableItem {
     /// Return the index of the `element` inside a collection of items
-    func index(of element: Item) -> Self.Index? {
+    func index(of element: TableItem) -> Self.Index? {
         return index(where: { $0 === element })
     }
 }

--- a/TableViewKit/TableSection.swift
+++ b/TableViewKit/TableSection.swift
@@ -1,12 +1,15 @@
 import Foundation
 import UIKit
 
+@available(*, deprecated, renamed: "TableSection")
+public typealias Section = TableSection
+
 /// A type that represent a section to be displayed
 /// containing `items`, a `header` and a `footer`
-public protocol Section: class, AnyEquatable {
+public protocol TableSection: class, AnyEquatable {
 
     /// A array containing the `items` of the section
-    var items: ObservableArray<Item> { get set }
+    var items: ObservableArray<TableItem> { get set }
 
     /// The `header` of the section, none if not defined
     /// - Default: none
@@ -17,7 +20,7 @@ public protocol Section: class, AnyEquatable {
     var index: Int? { get }
 }
 
-public extension Section where Self: Equatable {
+public extension TableSection where Self: Equatable {
 
     func equals(_ other: Any?) -> Bool {
         if let other = other as? Self {
@@ -27,7 +30,7 @@ public extension Section where Self: Equatable {
 }
 }
 
-extension Section {
+extension TableSection {
 
     /// Empty header
     public var header: HeaderFooterView { return nil }
@@ -38,7 +41,7 @@ extension Section {
 // swiftlint:disable:next identifier_name
 private var SectionTableViewManagerKey: UInt8 = 0
 
-extension Section {
+extension TableSection {
 
     public internal(set) var manager: TableViewManager? {
         get {
@@ -53,7 +56,7 @@ extension Section {
     }
 }
 
-extension Section {
+extension TableSection {
 
     public func equals(_ other: Any?) -> Bool {
         if let other = other as AnyObject? {
@@ -108,9 +111,9 @@ extension Section {
 
 }
 
-public extension Collection where Self.Iterator.Element == Section {
+public extension Collection where Self.Iterator.Element == TableSection {
     /// Return the index of the `element` inside a collection of sections
-    func index(of element: Section) -> Self.Index? {
+    func index(of element: TableSection) -> Self.Index? {
         return index(where: { $0 === element })
     }
 }

--- a/TableViewKit/TableViewKitDataSource.swift
+++ b/TableViewKit/TableViewKitDataSource.swift
@@ -3,7 +3,7 @@ import UIKit
 open class TableViewKitDataSource: NSObject, UITableViewDataSource {
 
     open unowned var manager: TableViewManager
-    private var sections: ObservableArray<Section> { return manager.sections }
+    private var sections: ObservableArray<TableSection> { return manager.sections }
 
     public required init(manager: TableViewManager) {
         self.manager = manager
@@ -52,7 +52,7 @@ open class TableViewKitDataSource: NSObject, UITableViewDataSource {
         return manager.item(at: indexPath) is Editable
     }
 
-    fileprivate func title(for key: (Section) -> HeaderFooterView, inSection section: Int) -> String? {
+    fileprivate func title(for key: (TableSection) -> HeaderFooterView, inSection section: Int) -> String? {
         if case .title(let value) = key(sections[section]) {
             return value
         }

--- a/TableViewKit/TableViewKitDelegate.swift
+++ b/TableViewKit/TableViewKitDelegate.swift
@@ -4,7 +4,7 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
 
     open unowned var manager: TableViewManager
     open weak var scrollDelegate: UIScrollViewDelegate?
-    private var sections: ObservableArray<Section> { return manager.sections }
+    private var sections: ObservableArray<TableSection> { return manager.sections }
 
     public required init(manager: TableViewManager) {
         self.manager = manager
@@ -98,7 +98,7 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
         scrollDelegate?.scrollViewDidEndDragging?(scrollView, willDecelerate: decelerate)
     }
 
-    fileprivate func view(for key: (Section) -> HeaderFooterView, inSection section: Int) -> UIView? {
+    fileprivate func view(for key: (TableSection) -> HeaderFooterView, inSection section: Int) -> UIView? {
         guard case .view(let item) = key(sections[section]) else { return nil }
 
         let drawer = type(of: item).drawer
@@ -108,7 +108,7 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
         return view
     }
 
-    fileprivate func estimatedHeight(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
+    fileprivate func estimatedHeight(for key: (TableSection) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
         let item = key(sections[section])
         switch item {
         case .view(let view):
@@ -126,7 +126,7 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
         return height.estimated
     }
 
-    fileprivate func height(for key: (Section) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
+    fileprivate func height(for key: (TableSection) -> HeaderFooterView, inSection section: Int) -> CGFloat? {
         guard case .view(let view) = key(sections[section]), let value = view.height
             else { return nil }
         return value.height

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -11,7 +11,7 @@ open class TableViewManager {
     open let tableView: UITableView
 
     /// An array of sections
-    open var sections: ObservableArray<Section>
+    open var sections: ObservableArray<TableSection>
 
     open var animation: UITableViewRowAnimation = .automatic
 
@@ -25,7 +25,7 @@ open class TableViewManager {
     ///
     /// - parameter tableView: A `tableView` that will be controlled by the `TableViewManager`
     /// - parameter sections: An array of sections
-    public init(tableView: UITableView, sections: [Section] = []) {
+    public init(tableView: UITableView, sections: [TableSection] = []) {
         self.tableView = tableView
         self.sections = ObservableArray(array: sections)
         self.setupDelegates()
@@ -42,7 +42,7 @@ open class TableViewManager {
         sections.callback = { [weak self] in self?.onSectionsUpdate(with: $0) }
     }
 
-    func onSectionsUpdate(with changes: ArrayChanges<Section>) {
+    func onSectionsUpdate(with changes: ArrayChanges<TableSection>) {
         switch changes {
         case .inserts(let indexes, let insertedSections):
             insertedSections.forEach { $0.register(in: self) }
@@ -71,7 +71,7 @@ open class TableViewManager {
         }
     }
 
-    func onItemsUpdate(with changes: ArrayChanges<Item>, forSectionIndex sectionIndex: Int) {
+    func onItemsUpdate(with changes: ArrayChanges<TableItem>, forSectionIndex sectionIndex: Int) {
 
         switch changes {
         case .inserts(let array, let insertedItems):
@@ -114,7 +114,7 @@ extension TableViewManager {
         }
     }
 
-    func item(at indexPath: IndexPath) -> Item {
+    func item(at indexPath: IndexPath) -> TableItem {
         return sections[indexPath.section].items[indexPath.row]
     }
 }

--- a/TableViewKitTests/TableViewDataSourceTests.swift
+++ b/TableViewKitTests/TableViewDataSourceTests.swift
@@ -17,14 +17,14 @@ extension HeaderFooterView: Equatable {
     }
 }
 
-class HeaderFooterTitleSection: Section {
-    var items: ObservableArray<Item> = []
+class HeaderFooterTitleSection: TableSection {
+    var items: ObservableArray<TableItem> = []
     weak var tableViewManager: TableViewManager!
 
     internal var header: HeaderFooterView { return .title("Header") }
     internal var footer: HeaderFooterView { return .title("Footer") }
 
-    convenience init(items: [Item]) {
+    convenience init(items: [TableItem]) {
         self.init()
         self.items.insert(contentsOf: items, at: 0)
     }
@@ -32,10 +32,10 @@ class HeaderFooterTitleSection: Section {
 
 class TestDrawer: CellDrawer {
     static internal var type = CellType.class(TestCell.self)
-    static internal func draw(_ cell: TestCell, with item: Item) { }
+    static internal func draw(_ cell: TestCell, with item: TableItem) { }
 }
 
-class TestItem: Item, Selectable {
+class TestItem: TableItem, Selectable {
     static internal var drawer = AnyCellDrawer(TestDrawer.self)
 
     public func didSelect() {
@@ -45,10 +45,10 @@ class TestItem: Item, Selectable {
 }
 
 class TestCell: UITableViewCell, ItemCompatible {
-    internal var item: Item?
+    internal var item: TableItem?
 }
 
-class DifferentItem: Item {
+class DifferentItem: TableItem {
 
     static var drawer = AnyCellDrawer(DifferentDrawer.self)
 }
@@ -97,7 +97,7 @@ class TableViewDataSourceTests: XCTestCase {
 
         let indexPath = otherItem.indexPath!
         let drawer = type(of: otherItem).drawer
-        let cell = drawer.cell(in: tableViewManager, with: otherItem as Item, for: indexPath)
+        let cell = drawer.cell(in: tableViewManager, with: otherItem as TableItem, for: indexPath)
 
         XCTAssertTrue(cell is DifferentCell)
     }

--- a/TableViewKitTests/TableViewDelegateTests.swift
+++ b/TableViewKitTests/TableViewDelegateTests.swift
@@ -2,10 +2,10 @@ import XCTest
 import TableViewKit
 import Nimble
 
-class NoHeaderFooterSection: Section {
-    var items: ObservableArray<Item> = []
+class NoHeaderFooterSection: TableSection {
+    var items: ObservableArray<TableItem> = []
 
-    convenience init(items: [Item]) {
+    convenience init(items: [TableItem]) {
         self.init()
         self.items.insert(contentsOf: items, at: 0)
     }
@@ -46,32 +46,32 @@ class ViewHeaderFooter: HeaderFooter {
     }
 }
 
-class ViewHeaderFooterSection: Section {
-    var items: ObservableArray<Item> = []
+class ViewHeaderFooterSection: TableSection {
+    var items: ObservableArray<TableItem> = []
 
     internal var header: HeaderFooterView = .view(ViewHeaderFooter(title: "First Section"))
     internal var footer: HeaderFooterView = .view(ViewHeaderFooter(title: "Section Footer\nHola"))
 
-    convenience init(items: [Item]) {
+    convenience init(items: [TableItem]) {
         self.init()
         self.items.insert(contentsOf: items, at: 0)
     }
 }
 
-class NoHeigthItem: Item {
+class NoHeigthItem: TableItem {
     static internal var drawer = AnyCellDrawer(TestDrawer.self)
 
     internal var height: Height?
 }
 
-class StaticHeigthItem: Item {
+class StaticHeigthItem: TableItem {
     static let testStaticHeightValue: CGFloat = 20.0
     static internal var drawer = AnyCellDrawer(TestDrawer.self)
 
     internal var height: Height? = .static(20.0)
 }
 
-class SelectableItem: Selectable, Item {
+class SelectableItem: Selectable, TableItem {
     static internal var drawer = AnyCellDrawer(TestDrawer.self)
 
     public var check: Int = 0
@@ -83,7 +83,7 @@ class SelectableItem: Selectable, Item {
     }
 }
 
-class ActionableItem: ActionPerformable, Item {
+class ActionableItem: ActionPerformable, TableItem {
     static internal var drawer = AnyCellDrawer(TestDrawer.self)
 
     public var check: Int = 0

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -14,7 +14,7 @@ class TestReloadDrawer: CellDrawer {
     }
 }
 
-class TestReloadItem: Item {
+class TestReloadItem: TableItem {
     static internal var drawer = AnyCellDrawer(TestReloadDrawer.self)
 
     internal var title: String?
@@ -46,7 +46,7 @@ class StatefulSection: HeaderFooterTitleSection, StaticStateful {
     }
 
     var currentState: StatefulSection.State = .login
-    var states: [StatefulSection.State : [Item]] = [:]
+    var states: [StatefulSection.State : [TableItem]] = [:]
 
     override init() {
         super.init()
@@ -92,7 +92,7 @@ class TableViewKitTests: XCTestCase {
 
         manager = TableViewManager(tableView: UITableView())
 
-        let item: Item = TestItem()
+        let item: TableItem = TestItem()
 
         let section = HeaderFooterTitleSection()
         section.items.append(item)
@@ -149,8 +149,8 @@ class TableViewKitTests: XCTestCase {
         manager = TableViewManager(tableView: UITableView())
         manager.sections.insert(HeaderFooterTitleSection(items: [TestItem()]), at: 0)
 
-        weak var section: Section? = manager.sections.first
-        weak var item: Item? = section!.items.first
+        weak var section: TableSection? = manager.sections.first
+        weak var item: TableItem? = section!.items.first
         expect(section).toNot(beNil())
         expect(item).toNot(beNil())
         manager.sections.replace(with: [HeaderFooterTitleSection()])
@@ -232,7 +232,7 @@ class TableViewKitTests: XCTestCase {
     func testNoCrashOnNonAddedItem() {
         manager = TableViewManager(tableView: UITableView(), sections: [HeaderFooterTitleSection()])
 
-        let item: Item = TestReloadItem()
+        let item: TableItem = TestReloadItem()
         item.reload(with: .automatic)
 
         let section = item.section


### PR DESCRIPTION
As title, this PR deprecates `Item` and `Section` in favour of `TableItem` and `TableSection`.

This is needed for a future support of `UICollectionView` in order to avoid conflicts and confusion.