### PR TITLE
Support redraw method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.0
+osx_image: xcode9
 script:
   - swiftlint
   - travis_retry sh build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9.0
 script:
   - swiftlint
   - travis_retry sh build.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- Official support to Swift 4
+- Support for `TableItem` method `redraw()`
 - Support for `scrollViewWillEndDragging`
 - Support for item's `copy` and `paste` action via `ActionPerformable`
 ### Changed

--- a/TableViewKit.xcodeproj/project.pbxproj
+++ b/TableViewKit.xcodeproj/project.pbxproj
@@ -261,11 +261,11 @@
 				TargetAttributes = {
 					CCBE455B1D72F69400414A64 = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0910;
 					};
 					CCBE45651D72F69500414A64 = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0910;
 					};
 				};
 			};
@@ -502,6 +502,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -520,6 +521,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.odigeo.TableViewKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -530,6 +532,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.odigeo.TableViewKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -540,6 +543,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.odigeo.TableViewKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/TableViewKit/ObservableArray.swift
+++ b/TableViewKit/ObservableArray.swift
@@ -106,7 +106,7 @@ public class ObservableArray<T>: RandomAccessCollection, ExpressibleByArrayLiter
     /// - parameter subrange: The subrange that must be replaced
     /// - parameter newElements: The new elements that must be replaced
     // swiftlint:disable:next line_length
-    public func replaceSubrange<C>(_ subrange: Range<Int>, with newElements: C) where C : Collection, C.Iterator.Element == T {
+    public func replaceSubrange<C>(_ subrange: Range<Int>, with newElements: C) where C: Collection, C.Iterator.Element == T {
         let temp = Array(newElements)
         var diff = Array.diff(between: self.array,
                               and: temp,

--- a/TableViewKit/Protocols/Selectable.swift
+++ b/TableViewKit/Protocols/Selectable.swift
@@ -13,7 +13,6 @@ extension Selectable {
     ///
     /// - parameter animated:       If the selection should be animated
     /// - parameter scrollPosition: The scrolling position
-    // swiftlint:disable:next line_length
     public func select(animated: Bool, scrollPosition: UITableViewScrollPosition = .none) {
         guard let tableView = manager?.tableView else { return }
 

--- a/TableViewKit/Protocols/Stateful.swift
+++ b/TableViewKit/Protocols/Stateful.swift
@@ -35,11 +35,18 @@ public extension Stateful {
     }
 }
 
-public protocol StaticStateful: Stateful {
-    associatedtype State: Hashable
+#if swift(>=3.2)
+    public protocol StaticStateful: Stateful where State: Hashable {
 
     var states: [State: [TableItem]] { get }
-}
+    }
+#else
+    public protocol StaticStateful: Stateful {
+        associatedtype State: Hashable
+
+        var states: [State: [TableItem]] { get }
+    }
+#endif
 
 public extension StaticStateful {
 

--- a/TableViewKit/Protocols/TableItem.swift
+++ b/TableViewKit/Protocols/TableItem.swift
@@ -92,7 +92,7 @@ extension TableItem {
         section?.items.callback?(.updates([indexPath.row]))
     }
 
-    /// Force redraw the `item` without reloading it
+    /// Redraw the associated `cell` of the `item` without reloading it
     /// The `draw` method of `CellDrawer` get called if the `cell` is visible
     public func redraw() {
         guard let cell = cell else { return }

--- a/TableViewKit/Protocols/TableItem.swift
+++ b/TableViewKit/Protocols/TableItem.swift
@@ -78,7 +78,7 @@ extension TableItem {
     }
 
     /// Returns the `cell` of the `item`, if visibile
-    public var cell: UITableViewCell? {
+    var cell: UITableViewCell? {
         guard let indexPath = indexPath else { return nil }
         return manager?.tableView.cellForRow(at: indexPath)
     }

--- a/TableViewKit/Protocols/TableItem.swift
+++ b/TableViewKit/Protocols/TableItem.swift
@@ -77,15 +77,26 @@ extension TableItem {
         return nil
     }
 
+    /// Returns the `cell` of the `item`, if visibile
+    public var cell: UITableViewCell? {
+        guard let indexPath = indexPath else { return nil }
+        return manager?.tableView.cellForRow(at: indexPath)
+    }
+
     /// Reload the `item` with an `animation`
     ///
     /// - parameter animation: A constant that indicates how the reloading is to be animated
-    ///
-    /// - returns: The `section` of the `item` or `nil` if not present
     public func reload(with animation: UITableViewRowAnimation = .automatic) {
         guard let indexPath = indexPath else { return }
         let section = manager?.sections[indexPath.section]
         section?.items.callback?(.updates([indexPath.row]))
+    }
+
+    /// Force redraw the `item` without reloading it
+    /// The `draw` method of `CellDrawer` get called if the `cell` is visible
+    public func redraw() {
+        guard let cell = cell else { return }
+        Self.drawer.draw(cell, self)
     }
 
 }

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -46,7 +46,7 @@ class StatefulSection: HeaderFooterTitleSection, StaticStateful {
     }
 
     var currentState: StatefulSection.State = .login
-    var states: [StatefulSection.State : [TableItem]] = [:]
+    var states: [StatefulSection.State: [TableItem]] = [:]
 
     override init() {
         super.init()

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -165,7 +165,6 @@ class TableViewKitTests: XCTestCase {
     }
 
     func testUpdateRow() {
-
         let item = TestReloadItem()
         item.title = "Before"
 
@@ -180,6 +179,27 @@ class TableViewKitTests: XCTestCase {
 
         item.title = "After"
         item.reload()
+
+        cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
+
+        expect(cell.textLabel?.text) == item.title
+    }
+
+    func testUpdateRowWithoutReload() {
+        let item = TestReloadItem()
+        item.title = "Before"
+
+        let section = HeaderFooterTitleSection(items: [item])
+        manager = TableViewManager(tableView: UITableView(), sections: [section])
+
+        guard let indexPath = item.indexPath else { return }
+        let dataSource = manager.dataSource!
+        var cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
+
+        expect(cell.textLabel?.text) == item.title
+
+        item.title = "After"
+        item.redraw()
 
         cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
 

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,6 @@ set -o pipefail &&
 time xcodebuild clean test \
     -workspace TableViewKit.xcworkspace \
     -scheme TableViewKit \
-    -sdk iphonesimulator10.3 \
-    -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.0' \
+    -sdk iphonesimulator11.0 \
+    -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.0' \
 | xcpretty


### PR DESCRIPTION
This add support for a new method of `TableItem`, which is `redraw()`.
It's useful for when we want to update the associated cell without the need of reloading with or without animation, which it can cause conflicts if it was happening together with insertions/deletions.