### PR TITLE
Added an inheritable ViewController as a helper to work with TableViewKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Improved/Fixed examples ([PR#34](https://github.com/odigeoteam/TableViewKit/pull/34), [PR#35](https://github.com/odigeoteam/TableViewKit/pull/35))
 - Added *prototype* cell type to use with Storyboard's prototype cells ([PR#36](https://github.com/odigeoteam/TableViewKit/pull/36))
+- Added an inheritable ViewController as a helper to work with TableViewKit
 
 ## [1.2.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Improved/Fixed examples ([PR#34](https://github.com/odigeoteam/TableViewKit/pull/34), [PR#35](https://github.com/odigeoteam/TableViewKit/pull/35))
 - Added *prototype* cell type to use with Storyboard's prototype cells ([PR#36](https://github.com/odigeoteam/TableViewKit/pull/36))
-- Added an inheritable ViewController as a helper to work with TableViewKit
+- Added `TableViewKitViewController` as an inheritable View Controller as a helper ([PR#37](https://github.com/odigeoteam/TableViewKit/pull/37))
 
 ## [1.2.0]
 ### Added

--- a/TableViewKit.xcodeproj/project.pbxproj
+++ b/TableViewKit.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		CCEF387E1D8D59C000F5893F /* NibClassType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEF387D1D8D59C000F5893F /* NibClassType.swift */; };
 		CCEF38801D8D5A7A00F5893F /* HeaderFooterDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEF387F1D8D5A7A00F5893F /* HeaderFooterDrawer.swift */; };
 		CCFD05CC1D95BD3C0063A002 /* Stateful.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFD05CB1D95BD3C0063A002 /* Stateful.swift */; };
+		D320F0601FC0BA550010D428 /* TableViewKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D320F05F1FC0BA550010D428 /* TableViewKitViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,6 +88,7 @@
 		CCEF387D1D8D59C000F5893F /* NibClassType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibClassType.swift; sourceTree = "<group>"; };
 		CCEF387F1D8D5A7A00F5893F /* HeaderFooterDrawer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HeaderFooterDrawer.swift; path = Protocols/HeaderFooterDrawer.swift; sourceTree = "<group>"; };
 		CCFD05CB1D95BD3C0063A002 /* Stateful.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Stateful.swift; path = Protocols/Stateful.swift; sourceTree = "<group>"; };
+		D320F05F1FC0BA550010D428 /* TableViewKitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewKitViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,6 +168,7 @@
 				CCBE458E1D72F79C00414A64 /* TableViewManager.swift */,
 				CC09F88A1EA791B7006FF4EA /* TableViewKitDelegate.swift */,
 				CC09F8881EA79178006FF4EA /* TableViewKitDataSource.swift */,
+				D320F05F1FC0BA550010D428 /* TableViewKitViewController.swift */,
 				CCBE455F1D72F69500414A64 /* TableViewKit.h */,
 				CCBE45611D72F69500414A64 /* Info.plist */,
 				CC5CF11B1D839E71004DECB3 /* ArrayDiff.swift */,
@@ -348,6 +351,7 @@
 				CC09F8891EA79178006FF4EA /* TableViewKitDataSource.swift in Sources */,
 				CCBE45931D72F79C00414A64 /* UITableView+Register.swift in Sources */,
 				CCBE459D1D72F79C00414A64 /* CellDrawer.swift in Sources */,
+				D320F0601FC0BA550010D428 /* TableViewKitViewController.swift in Sources */,
 				CCBE459F1D72F79C00414A64 /* TableItem.swift in Sources */,
 				CCCAC1221D7D9E440001FC1D /* (null) in Sources */,
 			);

--- a/TableViewKit.xcodeproj/project.pbxproj
+++ b/TableViewKit.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2564E61C1D88450F00A9DC3E /* TestRegisterHeaderFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2564E61B1D88450F00A9DC3E /* TestRegisterHeaderFooterView.xib */; };
 		25837C781D87F819001EF4B8 /* ItemCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25837C771D87F819001EF4B8 /* ItemCompatible.swift */; };
 		25B0B7541DC74F6C00591467 /* Editable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B0B7531DC74F6C00591467 /* Editable.swift */; };
+		34A206811FC33340009A7ED3 /* TableViewManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34A206801FC33340009A7ED3 /* TableViewManagerTests.swift */; };
 		CC09F8891EA79178006FF4EA /* TableViewKitDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC09F8881EA79178006FF4EA /* TableViewKitDataSource.swift */; };
 		CC09F88B1EA791B7006FF4EA /* TableViewKitDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC09F88A1EA791B7006FF4EA /* TableViewKitDelegate.swift */; };
 		CC0DE2C81DE33B9C00E2EDE5 /* AnyEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DE2C71DE33B9C00E2EDE5 /* AnyEquatable.swift */; };
@@ -59,6 +60,7 @@
 		2564E61B1D88450F00A9DC3E /* TestRegisterHeaderFooterView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TestRegisterHeaderFooterView.xib; sourceTree = "<group>"; };
 		25837C771D87F819001EF4B8 /* ItemCompatible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ItemCompatible.swift; path = Protocols/ItemCompatible.swift; sourceTree = "<group>"; };
 		25B0B7531DC74F6C00591467 /* Editable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Editable.swift; path = Protocols/Editable.swift; sourceTree = "<group>"; };
+		34A206801FC33340009A7ED3 /* TableViewManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewManagerTests.swift; sourceTree = "<group>"; };
 		4BCAD51C1D89A704002F3420 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "External/Nimble/build/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
 		CC09F8881EA79178006FF4EA /* TableViewKitDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewKitDataSource.swift; sourceTree = "<group>"; };
 		CC09F88A1EA791B7006FF4EA /* TableViewKitDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewKitDelegate.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				CCE400F51D731B7300537715 /* TableViewDataSourceTests.swift */,
 				CC12F72A1F2611BE00F20671 /* ArrayChangesUtils.swift */,
 				CCBE456B1D72F69500414A64 /* TableViewKitTests.swift */,
+				34A206801FC33340009A7ED3 /* TableViewManagerTests.swift */,
 				2519E1CC1E015A0A0021E06E /* ObservableArrayTests.swift */,
 				CCBE456D1D72F69500414A64 /* Info.plist */,
 				2564E6191D88419B00A9DC3E /* TestRegisterNibCell.xib */,
@@ -366,6 +369,7 @@
 				CC9D50E11D8496180010FCA3 /* TableViewDelegateTests.swift in Sources */,
 				CCE400F61D731B7300537715 /* TableViewDataSourceTests.swift in Sources */,
 				CCBE456C1D72F69500414A64 /* TableViewKitTests.swift in Sources */,
+				34A206811FC33340009A7ED3 /* TableViewManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TableViewKit/TableViewKitViewController.swift
+++ b/TableViewKit/TableViewKitViewController.swift
@@ -3,12 +3,12 @@ import UIKit
 /// Helper for using TableViewKit inheriting from a UITableViewController
 /// It can be used with a XIB file or Storyboards
 open class TableViewKitViewController: UITableViewController {
-	
-	open var tableViewManager: TableViewManager!
+
+    open var tableViewManager: TableViewManager!
 
     override open func viewDidLoad() {
-		super.viewDidLoad()
-		tableViewManager = TableViewManager(tableView: tableView)
+        super.viewDidLoad()
+        tableViewManager = TableViewManager(tableView: tableView)
     }
 
 }

--- a/TableViewKit/TableViewKitViewController.swift
+++ b/TableViewKit/TableViewKitViewController.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+/// Helper for using TableViewKit inheriting from a UITableViewController
+/// It can be used with a XIB file or Storyboards
+open class TableViewKitViewController: UITableViewController {
+	
+	open var tableViewManager: TableViewManager!
+
+    override open func viewDidLoad() {
+		super.viewDidLoad()
+		tableViewManager = TableViewManager(tableView: tableView)
+    }
+
+}

--- a/TableViewKitTests/TableViewKitTests.swift
+++ b/TableViewKitTests/TableViewKitTests.swift
@@ -85,44 +85,12 @@ class TestRegisterPrototypeTableView: UITableView {
 
 class TableViewKitTests: XCTestCase {
 
-    var manager: TableViewManager!
-
     override func setUp() {
         super.setUp()
     }
 
     override func tearDown() {
         super.tearDown()
-        manager = nil
-    }
-
-    func testAddSection() {
-        manager = TableViewManager(tableView: UITableView())
-
-        let section = HeaderFooterTitleSection()
-        manager.sections.append(section)
-
-        expect(self.manager.sections.count) == 1
-    }
-
-    func testAddItem() {
-
-        manager = TableViewManager(tableView: UITableView())
-
-        let item: TableItem = TestItem()
-
-        let section = HeaderFooterTitleSection()
-        section.items.append(item)
-
-        manager.sections.insert(section, at: 0)
-
-        expect(section.items.count) == 1
-        expect(item.section).notTo(beNil())
-
-        section.items.remove(at: 0)
-        section.items.append(item)
-
-        section.items.replace(with: [TestItem(), item])
     }
 
     func testEqualableItem() {
@@ -160,120 +128,6 @@ class TableViewKitTests: XCTestCase {
 
         XCTAssert(section1.equals(section2) == false)
         XCTAssert(section1.equals(nil) == false)
-    }
-
-    func testRetainCycle() {
-        manager = TableViewManager(tableView: UITableView())
-        manager.sections.insert(HeaderFooterTitleSection(items: [TestItem()]), at: 0)
-
-        weak var section: TableSection? = manager.sections.first
-        weak var item: TableItem? = section!.items.first
-        expect(section).toNot(beNil())
-        expect(item).toNot(beNil())
-        manager.sections.replace(with: [HeaderFooterTitleSection()])
-        expect(section).to(beNil())
-        expect(item).to(beNil())
-    }
-
-    func testConvenienceInit() {
-        manager = TableViewManager(tableView: UITableView(), sections: [HeaderFooterTitleSection()])
-
-        expect(self.manager.sections.count) == 1
-    }
-
-    func testUpdateRow() {
-        let item = TestReloadItem()
-        item.title = "Before"
-
-        let section = HeaderFooterTitleSection(items: [item])
-        manager = TableViewManager(tableView: UITableView(), sections: [section])
-
-        guard let indexPath = item.indexPath else { return }
-		let dataSource = manager.dataSource!
-        var cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
-
-        expect(cell.textLabel?.text) == item.title
-
-        item.title = "After"
-        item.reload()
-
-        cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
-
-        expect(cell.textLabel?.text) == item.title
-    }
-
-    func testUpdateRowWithoutReload() {
-        let item = TestReloadItem()
-        item.title = "Before"
-
-        let section = HeaderFooterTitleSection(items: [item])
-        manager = TableViewManager(tableView: UITableView(), sections: [section])
-
-        guard let indexPath = item.indexPath else { return }
-        let dataSource = manager.dataSource!
-        var cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
-
-        expect(cell.textLabel?.text) == item.title
-
-        item.title = "After"
-        item.redraw()
-
-        cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
-
-        expect(cell.textLabel?.text) == item.title
-    }
-
-    func testMoveRows() {
-
-        let tableView = UITableView()
-
-        let item1 = TestItem()
-        let item2 = TestItem()
-
-        let section = NoHeaderFooterSection(items: [item1, item2])
-        manager = TableViewManager(tableView: tableView, sections: [section])
-
-        var indexPathItem1 = item1.indexPath
-        var indexPathItem2 = item2.indexPath
-
-        XCTAssertNotNil(indexPathItem1)
-        XCTAssertNotNil(indexPathItem2)
-
-        section.items.replace(with: [item2, item1])
-
-        indexPathItem1 = item1.indexPath
-        indexPathItem2 = item2.indexPath
-
-        XCTAssert(indexPathItem2?.item == 0)
-        XCTAssert(indexPathItem1?.item == 1)
-    }
-
-    func testMoveSections() {
-
-        let tableView = UITableView()
-
-        let section1 = NoHeaderFooterSection()
-        let section2 = NoHeaderFooterSection()
-
-        manager = TableViewManager(tableView: tableView, sections: [section1, section2])
-
-        XCTAssert(section1.index == 0)
-        XCTAssert(section2.index == 1)
-
-        manager.sections.replace(with: [section2, section1])
-
-        XCTAssert(section1.index == 1)
-        XCTAssert(section2.index == 0)
-    }
-
-    func testNoCrashOnNonAddedItem() {
-        manager = TableViewManager(tableView: UITableView(), sections: [HeaderFooterTitleSection()])
-
-        let item: TableItem = TestReloadItem()
-        item.reload(with: .automatic)
-
-        let section = item.section
-        expect(section).to(beNil())
     }
 
     func testRegisterNibCells() {
@@ -369,42 +223,15 @@ class TableViewKitTests: XCTestCase {
         XCTAssert(registerItem?.title == "Register")
     }
 
-    func testManagerProperty() {
+    func testTableViewKitViewControllerInit() {
         let tableView = UITableView()
+        let viewController = TableViewKitViewController()
+        viewController.tableView = tableView
 
-        let item1 = TestItem()
-        XCTAssertNil(item1.manager)
-        let section = NoHeaderFooterSection(items: [item1])
-        XCTAssertNil(section.manager)
+        viewController.viewDidLoad()
 
-        manager = TableViewManager(tableView: tableView, sections: [section])
-        XCTAssert(item1.manager === manager)
-        XCTAssert(section.manager === manager)
-
-        let section2 = NoHeaderFooterSection(items: [item1])
-        manager.sections.append(section2)
-        XCTAssert(section2.manager === manager)
-
-        let item2 = TestItem()
-        section.items.append(item2)
-        XCTAssert(item2.manager === manager)
-
-        let removedSection = manager.sections.removeLast()
-
-        XCTAssert(removedSection === section2)
-        XCTAssertNil(removedSection.manager)
-        XCTAssertNil(removedSection.items[0].manager)
-
-        manager.sections.append(removedSection)
-
-        XCTAssertNotNil(removedSection.manager)
-        XCTAssertNotNil(removedSection.items[0].manager)
-
-        let removedFirstSection = manager.sections.removeFirst()
-
-        XCTAssert(removedFirstSection === section)
-        XCTAssertNil(removedFirstSection.manager)
-        XCTAssertNil(removedFirstSection.items[0].manager)
-
+        expect(viewController.tableViewManager).toNot(beNil())
+        expect(viewController.tableView) == tableView
     }
+
 }

--- a/TableViewKitTests/TableViewManagerTests.swift
+++ b/TableViewKitTests/TableViewManagerTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+import Nimble
+
+@testable import TableViewKit
+
+class TableViewManagerTests: XCTestCase {
+
+    var manager: TableViewManager!
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        manager = nil
+    }
+
+    func testAddSection() {
+        manager = TableViewManager(tableView: UITableView())
+
+        let section = HeaderFooterTitleSection()
+        manager.sections.append(section)
+
+        expect(self.manager.sections.count) == 1
+    }
+
+    func testAddItem() {
+
+        manager = TableViewManager(tableView: UITableView())
+
+        let item: TableItem = TestItem()
+
+        let section = HeaderFooterTitleSection()
+        section.items.append(item)
+
+        manager.sections.insert(section, at: 0)
+
+        expect(section.items.count) == 1
+        expect(item.section).notTo(beNil())
+
+        section.items.remove(at: 0)
+        section.items.append(item)
+
+        section.items.replace(with: [TestItem(), item])
+    }
+
+    func testUpdateRow() {
+        let item = TestReloadItem()
+        item.title = "Before"
+
+        let section = HeaderFooterTitleSection(items: [item])
+        manager = TableViewManager(tableView: UITableView(), sections: [section])
+
+        guard let indexPath = item.indexPath else { return }
+        let dataSource = manager.dataSource!
+        var cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
+
+        expect(cell.textLabel?.text) == item.title
+
+        item.title = "After"
+        item.reload()
+
+        cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
+
+        expect(cell.textLabel?.text) == item.title
+    }
+
+    func testUpdateRowWithoutReload() {
+        let item = TestReloadItem()
+        item.title = "Before"
+
+        let section = HeaderFooterTitleSection(items: [item])
+        manager = TableViewManager(tableView: UITableView(), sections: [section])
+
+        guard let indexPath = item.indexPath else { return }
+        let dataSource = manager.dataSource!
+        var cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
+
+        expect(cell.textLabel?.text) == item.title
+
+        item.title = "After"
+        item.redraw()
+
+        cell = dataSource.tableView(manager.tableView, cellForRowAt: indexPath)
+
+        expect(cell.textLabel?.text) == item.title
+    }
+
+    func testMoveRows() {
+
+        let tableView = UITableView()
+
+        let item1 = TestItem()
+        let item2 = TestItem()
+
+        let section = NoHeaderFooterSection(items: [item1, item2])
+        manager = TableViewManager(tableView: tableView, sections: [section])
+
+        var indexPathItem1 = item1.indexPath
+        var indexPathItem2 = item2.indexPath
+
+        XCTAssertNotNil(indexPathItem1)
+        XCTAssertNotNil(indexPathItem2)
+
+        section.items.replace(with: [item2, item1])
+
+        indexPathItem1 = item1.indexPath
+        indexPathItem2 = item2.indexPath
+
+        XCTAssert(indexPathItem2?.item == 0)
+        XCTAssert(indexPathItem1?.item == 1)
+    }
+
+    func testMoveSections() {
+
+        let tableView = UITableView()
+
+        let section1 = NoHeaderFooterSection()
+        let section2 = NoHeaderFooterSection()
+
+        manager = TableViewManager(tableView: tableView, sections: [section1, section2])
+
+        XCTAssert(section1.index == 0)
+        XCTAssert(section2.index == 1)
+
+        manager.sections.replace(with: [section2, section1])
+
+        XCTAssert(section1.index == 1)
+        XCTAssert(section2.index == 0)
+    }
+
+    func testNoCrashOnNonAddedItem() {
+        manager = TableViewManager(tableView: UITableView(), sections: [HeaderFooterTitleSection()])
+
+        let item: TableItem = TestReloadItem()
+        item.reload(with: .automatic)
+
+        let section = item.section
+        expect(section).to(beNil())
+    }
+
+    func testRetainCycle() {
+        manager = TableViewManager(tableView: UITableView())
+        manager.sections.insert(HeaderFooterTitleSection(items: [TestItem()]), at: 0)
+
+        weak var section: TableSection? = manager.sections.first
+        weak var item: TableItem? = section!.items.first
+        expect(section).toNot(beNil())
+        expect(item).toNot(beNil())
+        manager.sections.replace(with: [HeaderFooterTitleSection()])
+        expect(section).to(beNil())
+        expect(item).to(beNil())
+    }
+
+    func testConvenienceInit() {
+        manager = TableViewManager(tableView: UITableView(), sections: [HeaderFooterTitleSection()])
+
+        expect(self.manager.sections.count) == 1
+    }
+
+    func testManagerProperty() {
+        let tableView = UITableView()
+
+        let item1 = TestItem()
+        XCTAssertNil(item1.manager)
+        let section = NoHeaderFooterSection(items: [item1])
+        XCTAssertNil(section.manager)
+
+        manager = TableViewManager(tableView: tableView, sections: [section])
+        XCTAssert(item1.manager === manager)
+        XCTAssert(section.manager === manager)
+
+        let section2 = NoHeaderFooterSection(items: [item1])
+        manager.sections.append(section2)
+        XCTAssert(section2.manager === manager)
+
+        let item2 = TestItem()
+        section.items.append(item2)
+        XCTAssert(item2.manager === manager)
+
+        let removedSection = manager.sections.removeLast()
+
+        XCTAssert(removedSection === section2)
+        XCTAssertNil(removedSection.manager)
+        XCTAssertNil(removedSection.items[0].manager)
+
+        manager.sections.append(removedSection)
+
+        XCTAssertNotNil(removedSection.manager)
+        XCTAssertNotNil(removedSection.items[0].manager)
+
+        let removedFirstSection = manager.sections.removeFirst()
+
+        XCTAssert(removedFirstSection === section)
+        XCTAssertNil(removedFirstSection.manager)
+        XCTAssertNil(removedFirstSection.items[0].manager)
+
+    }
+
+}


### PR DESCRIPTION
Added an inheritable ViewController as a helper to work with TableViewKit:
- It'd avoid the tableViewManager boilerplate code
- It'd standardise the tableViewManager property naming
- It'd allow Xcode's new UIViewController to create a UITableView XIB directly
- It'd allow to use Storyboard's UITableViewController Scene
- It'd allow to make the library's Quick Start easier
- It'd give you the features of UITableViewController, such as the refreshControl, for free
