### PR TITLE
Improve initial slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ---
 ## [Unreleased]
 
+- Improved initial slicing for diff algorithm ([PR#39](https://github.com/odigeoteam/TableViewKit/pull/39))
 - Fixed ObservableArray setter ([PR#38](https://github.com/odigeoteam/TableViewKit/pull/38))
 - Improved/Fixed examples ([PR#34](https://github.com/odigeoteam/TableViewKit/pull/34), [PR#35](https://github.com/odigeoteam/TableViewKit/pull/35))
 - Added *prototype* cell type to use with Storyboard's prototype cells ([PR#36](https://github.com/odigeoteam/TableViewKit/pull/36))

--- a/TableViewKit/ArrayDiff.swift
+++ b/TableViewKit/ArrayDiff.swift
@@ -36,6 +36,67 @@ enum ArrayIndexesChanges {
     case endUpdates
 }
 
+struct Movement: Hashable {
+    var hashValue: Int { return from.hashValue ^ to.hashValue }
+
+    static func == (lhs: Movement, rhs: Movement) -> Bool {
+        return (lhs.from == rhs.from && lhs.to == rhs.to)
+    }
+
+    let from: Int
+    let to: Int
+}
+
+extension Array where Element == ArrayIndexesChanges {
+    func filterInsertsIndexes(withOffset offset: Int) -> [Int] {
+        return flatMap { change -> Int? in
+            guard case .inserts(let index) = change else { return nil }
+            return index + offset
+        }
+    }
+
+    func filterDeletesIndexes(withOffset offset: Int) -> [Int] {
+        return flatMap { change -> Int? in
+            guard case .deletes(let index) = change else { return nil }
+            return index + offset
+        }
+    }
+
+    func filterMovesIndexes<Element>(insertsIndexes: inout [Int],
+                                     deletesIndexes: inout [Int],
+                                     between x: ArraySlice<Element>,
+                                     and y: ArraySlice<Element>,
+                                     where predicate: (Element, Element) -> Bool) -> [(Int, Int)] {
+        var moves = Set<Movement>()
+        let rangeX = (x.startIndex..<x.endIndex)
+        let rangeY = (y.startIndex..<y.endIndex)
+
+        var deleted: Int = 0
+        for (deleteIndex, deleteAtIndex) in deletesIndexes.enumerated() {
+            for (insertIndex, insertAtIndex) in insertsIndexes.enumerated() {
+                if rangeX.contains(deleteAtIndex) &&
+                    rangeY.contains(insertAtIndex) &&
+                    predicate(x[deleteAtIndex], y[insertAtIndex]) {
+                    deletesIndexes.remove(at: deleteIndex - deleted)
+                    insertsIndexes.remove(at: insertIndex)
+                    let movement: Movement
+                    if deleteAtIndex < insertAtIndex {
+                        movement = Movement(from: deleteAtIndex, to: insertAtIndex)
+                    } else {
+                        movement = Movement(from: insertAtIndex, to: deleteAtIndex)
+                    }
+                    moves.insert(movement)
+
+                    deleted += 1
+                    break
+                }
+            }
+        }
+
+        return moves.map { ($0.from, $0.to) }
+    }
+}
+
 class DiffIterator: IteratorProtocol {
     struct Coordinates {
         var x: Int
@@ -113,14 +174,85 @@ extension Array {
     static func diff(between x: [Element], and y: [Element],
                      subrange: Range<Index>? = nil,
                      where predicate: Predicate) -> Diff<Element> {
-        let subarray: [Element] = {
-            guard let subrange = subrange else { return x }
-            return Array(x[subrange.lowerBound..<subrange.upperBound])
-        }()
-        let lowerBond: Int = subrange?.lowerBound ?? 0
+        let sliceOfX: ArraySlice<Element>
+        let sliceOfY: ArraySlice<Element>
+        if let subrange = subrange {
+            sliceOfX = x[subrange]
+            sliceOfY = y[y.startIndex..<y.endIndex]
+        } else if x.startIndex == y.startIndex && x.endIndex == y.endIndex {
+            sliceOfX = makeOptimalSlice(between: x, and: y, where: predicate)
+            sliceOfY = y[sliceOfX.startIndex..<sliceOfX.endIndex]
+        } else {
+            sliceOfX = x[x.startIndex..<x.endIndex]
+            sliceOfY = y[y.startIndex..<y.endIndex]
+        }
 
-        var matrix = Matrix(rows: subarray.count + 1, columns: y.count + 1, repeatedValue: 0)
-        for (i, xElem) in subarray.enumerated() {
+        let matrix = makeLCSMatrix(between: sliceOfX, and: sliceOfY, where: predicate)
+
+        let changes = [ArrayIndexesChanges](DiffSequence(matrix: matrix))
+
+        let lowerBound = sliceOfX.startIndex
+        var inserts = changes
+            .filterInsertsIndexes(withOffset: lowerBound)
+            .sorted { $0 > $1 }
+
+        var deletes = changes
+            .filterDeletesIndexes(withOffset: lowerBound)
+            .sorted { $0 < $1 }
+
+        let moves = changes
+            .filterMovesIndexes(insertsIndexes: &inserts,
+                                deletesIndexes: &deletes,
+                                between: sliceOfX,
+                                and: sliceOfY,
+                                where: predicate)
+
+        let diff = Diff(inserts: inserts,
+                        deletes: deletes,
+                        moves: moves,
+                        insertsElement: inserts.flatMap { y[$0 - lowerBound] },
+                        deletesElement: deletes.flatMap { x[$0] },
+                        fromElements: x,
+                        toElements: y)
+
+        return diff
+    }
+
+    static func makeOptimalSlice(between x: [Element],
+                                 and y: [Element],
+                                 where predicate: Predicate) -> ArraySlice<Element> {
+        var startIndex = x.startIndex
+        var endIndex = x.endIndex
+
+        for (i, xElem) in x.lazy.enumerated() {
+            guard i < y.count else { break }
+
+            startIndex = i
+            let yElem = y[i]
+            if !predicate(xElem, yElem) {
+                break
+            }
+        }
+
+        for (i, xElem) in x.lazy.enumerated().reversed() {
+            guard i < y.count, startIndex < endIndex else { break }
+
+            endIndex = i + 1
+            let yElem = y[i]
+            if !predicate(xElem, yElem) {
+                break
+            }
+
+        }
+
+        return x[startIndex..<endIndex]
+    }
+
+    static func makeLCSMatrix(between x: ArraySlice<Element>,
+                              and y: ArraySlice<Element>,
+                              where predicate: Predicate) -> Matrix<Int> {
+        var matrix = Matrix(rows: x.count + 1, columns: y.count + 1, repeatedValue: 0)
+        for (i, xElem) in x.enumerated() {
             for (j, yElem) in y.enumerated() {
                 if predicate(xElem, yElem) {
                     matrix[i + 1, j + 1] = matrix[i, j] + 1
@@ -129,43 +261,7 @@ extension Array {
                 }
             }
         }
-
-        let changes = [ArrayIndexesChanges](DiffSequence(matrix: matrix))
-        var inserts: [Int] = changes.flatMap { change -> Int? in
-            guard case .inserts(let index) = change else { return nil }
-            return index + lowerBond
-        }.sorted { $0 > $1 }
-
-        var deletes: [Int] = changes.flatMap { change -> Int? in
-            guard case .deletes(let index) = change else { return nil }
-            return index + lowerBond
-        }.sorted { $0 < $1 }
-
-        var moves: [(Int, Int)] = []
-
-        var deleted: Int = 0
-        for (deleteIndex, deleteAtIndex) in deletes.enumerated() {
-            let elem = x[deleteAtIndex]
-            let temp = inserts.index { predicate(y[$0 - lowerBond], elem) }
-            guard let insertIndex = temp else { continue }
-
-            let insertAtIndex = inserts[insertIndex]
-            deletes.remove(at: deleteIndex - deleted)
-            inserts.remove(at: insertIndex)
-            let movement = (deleteAtIndex, insertAtIndex)
-            moves.append(movement)
-            deleted += 1
-        }
-
-        let diff = Diff(inserts: inserts,
-                        deletes: deletes,
-                        moves: moves,
-                        insertsElement: inserts.flatMap { y[$0 - lowerBond] },
-                        deletesElement: deletes.flatMap { x[$0] },
-                        fromElements: x,
-                        toElements: y)
-
-        return diff
+        return matrix
     }
 
 }

--- a/TableViewKit/ObservableArray.swift
+++ b/TableViewKit/ObservableArray.swift
@@ -95,7 +95,6 @@ public class ObservableArray<T>: RandomAccessCollection, ExpressibleByArrayLiter
 
         let diff = Array.diff(between: self.array,
                               and: array,
-                              subrange: 0..<self.array.count,
                               where: compare)
         self.array = array
         notifyChanges(with: diff)

--- a/TableViewKitTests/ArrayChangesUtils.swift
+++ b/TableViewKitTests/ArrayChangesUtils.swift
@@ -3,32 +3,26 @@ import Foundation
 
 extension ArrayChanges: Equatable {
     public static func == (lhs: ArrayChanges<Element>, rhs: ArrayChanges<Element>) -> Bool {
+        guard
+            let lhs = lhs as? ArrayChanges<Int>,
+            let rhs = rhs as? ArrayChanges<Int> else { return false }
         switch (lhs, rhs) {
         case (let .inserts(indexesLhs, elementsLhs),
               let .inserts(indexesRhs, elementsRhs)),
              (let .deletes(indexesLhs, elementsLhs),
               let .deletes(indexesRhs, elementsRhs)):
-            if let elementsLhs = elementsLhs as? [Int],
-                let elementsRhs = elementsRhs as? [Int] {
-                return indexesLhs == indexesRhs && elementsLhs == elementsRhs
-            } else {
-                return false
-            }
+            return indexesLhs == indexesRhs && elementsLhs == elementsRhs
         case (let .updates(indexesLhs),
               let .updates(indexesRhs)):
             return indexesLhs == indexesRhs
         case (let .moves(indexesLhs),
               let .moves(indexesRhs)):
-            guard indexesLhs.count == indexesRhs.count else {
-                return false
-            }
-            return zip(indexesLhs, indexesRhs).reduce(true, { (carry, arg) -> Bool in
-                let ((fromLhs, toLhs), (fromRhs, toRhs)) = arg
-                return carry && (fromLhs == fromRhs && toLhs == toRhs)
-            })
-        case (.beginUpdates, .beginUpdates),
-             (.endUpdates, .endUpdates):
-            return true
+            return indexesLhs.elementsEqual(indexesRhs, by: { $0.0 == $1.0 && $0.1 == $1.1 })
+        case (let .beginUpdates(fromElementsLhs, toElementsLhs),
+              let .beginUpdates(fromElementsRhs, toElementsRhs)),
+             (let .endUpdates(fromElementsLhs, toElementsLhs),
+              let .endUpdates(fromElementsRhs, toElementsRhs)):
+            return fromElementsLhs == fromElementsRhs && toElementsLhs == toElementsRhs
         default:
             return false
         }

--- a/TableViewKitTests/ObservableArrayTests.swift
+++ b/TableViewKitTests/ObservableArrayTests.swift
@@ -15,6 +15,7 @@ class ObservableArrayTests: XCTestCase {
     var results: [ArrayChanges<Int>]!
     var numbers: ObservableArray<Int>!
     var expectedResults: [ArrayChanges<Int>]!
+    let from = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     override func setUp() {
         super.setUp()
         results = []
@@ -31,154 +32,201 @@ class ObservableArrayTests: XCTestCase {
     }
 
     func reset() {
-        let array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        numbers.replace(with: array, shouldPerformDiff: false)
+        numbers.replace(with: from, shouldPerformDiff: false)
         results = []
     }
 
     func testRemoveFirst() {
         reset()
         numbers.removeFirst()
+        var to = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .deletes([0], [0]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
 
         reset()
+        to = [3, 4, 5, 6, 7, 8, 9]
         numbers.removeFirst(3)
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .deletes([0, 1, 2], [0, 1, 2]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 
     func testRemoveLast() {
         reset()
         numbers.removeLast()
+        var to = [0, 1, 2, 3, 4, 5, 6, 7, 8]
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .deletes([9], [9]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
 
         reset()
         numbers.removeLast(3)
+        to = [0, 1, 2, 3, 4, 5, 6]
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .deletes([7, 8, 9], [7, 8, 9]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 
     func testRemoveAt() {
+        let to = [0, 1, 2, 3, 4, 6, 7, 8, 9]
         reset()
         numbers.remove(at: 5)
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .deletes([5], [5]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 
     func testRemoveAll() {
+        let to = [Int]()
         reset()
         numbers.removeAll()
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .deletes([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-                                 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-            .endUpdates(from: [], to: [])]
+                     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 
     func testAppend() {
+        let to = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         reset()
         numbers.append(10)
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .inserts([10], [10]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 
     func testAppendContentsOf() {
+        let to = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
         reset()
         numbers.append(contentsOf: [10, 11])
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .inserts([11, 10], [11, 10]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 
     func testInsertAt() {
+        var to = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         reset()
         numbers.insert(-1, at: 0)
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .inserts([0], [-1]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
 
         reset()
+        to = [0, 1, 2, 3, 4, -1, 5, 6, 7, 8, 9]
         numbers.insert(-1, at: 5)
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .inserts([5], [-1]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 
     func testInsertContentsOf() {
+        var to = [-1, -2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         reset()
         numbers.insert(contentsOf: [-1, -2], at: 0)
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .inserts([1, 0], [-2, -1]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
 
         reset()
+        to = [0, 1, 2, 3, 4, -1, -2, 5, 6, 7, 8, 9]
         numbers.insert(contentsOf: [-1, -2], at: 5)
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .inserts([6, 5], [-2, -1]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 
     func testMove() {
+        let to = [0, 1, 2, 4, 5, 6, 7, 3, 8, 9]
         reset()
-        numbers.replace(with: [0, 1, 2, 4, 5, 6, 7, 3, 8, 9])
+        numbers.replace(with: to)
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .moves([(3, 7)]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
+        expect(self.results) == expectedResults
+    }
+
+    func testMoveFromBeginning() {
+        let to = [9, 1, 2, 3, 4, 5, 6, 7, 8, 0]
+        reset()
+        numbers.replace(with: to)
+        expectedResults = [
+            .beginUpdates(from: from, to: to),
+            .moves([(0, 9)]),
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 
     func testReplaces() {
+        let to = [11, 0, 7, 2, 1, 3, 12, 13, 4, 6, 14, 8, 9]
         reset()
-        numbers.replace(with: [11, 0, 7, 2, 1, 3, 12, 13, 4, 6, 14, 8, 9])
+        numbers.replace(with: to)
         expectedResults = [
-            .beginUpdates(from: [], to: []),
-            .moves([(1, 4), (7, 2)]),
+            .beginUpdates(from: from, to: to),
+            .moves([(1, 4), (2, 7)]),
             .deletes([5], [5]),
             .inserts([10, 7, 6, 0], [14, 13, 12, 11]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
+        expect(self.results) == expectedResults
+    }
+
+    func testReplacesAllNew() {
+        let to = [100, 101, 102, 103, 104, 105, 106, 107, 108, 109]
+        reset()
+        numbers.replace(with: to)
+        expectedResults = [
+            .beginUpdates(from: from, to: to),
+            .deletes([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            .inserts([9, 8, 7, 6, 5, 4, 3, 2, 1, 0], [109, 108, 107, 106, 105, 104, 103, 102, 101, 100]),
+            .endUpdates(from: from, to: to)]
+        expect(self.results) == expectedResults
+    }
+
+    func testReplacesAllSame() {
+        let to = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        reset()
+        numbers.replace(with: to)
+        expectedResults = [
+            .beginUpdates(from: from, to: to),
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 
     func testReplaceSingleValue() {
+        let to = [0, 1, 99, 3, 4, 5, 6, 7, 8, 9]
         reset()
         numbers[2] = 99
         expectedResults = [
-            .beginUpdates(from: [], to: []),
+            .beginUpdates(from: from, to: to),
             .deletes([2], [2]),
             .inserts([2], [99]),
-            .endUpdates(from: [], to: [])]
+            .endUpdates(from: from, to: to)]
         expect(self.results) == expectedResults
     }
 }


### PR DESCRIPTION
Hi,

This PR reduces, in some cases, the amount of elements needed to generate the LCS matrix, bringing less memory impact.
It also extracts some of the logic from the diff algorithm to make it more readable.

Example:

| A | B |
| ------ | ------ |
| 1 | 1 |
| 2 | 2 |
| 3 | 3 |
| **4** | **8** |
| 5 | 5 |
| 6 | 6 |

A and B are two arrays with a single element difference at index 3 (_the value changes from 4 to 8_). 
With the current implementation, the LCS matrix will be composed by `n x n` elements.
We can intuitively think that we only need to compare a part, in this case, the element at index 3.
What we need is to find where the two arrays start to diverge and only executing the diff from that subarray.

By lineally comparing each pair from beginning to the end and reverse, we find a new `startIndex` and `endIndex`, to be used as range to slice the subarray.
Therefor the LCS matrix will be only composed by `subarray.lenghtxsubarray.lenght`, where `subarray.lenght` is at most `n` but very likely to minor (in the example would be 1 instead of 6).

_Important, this improvements only affects the usage of `a.replace(with: b)`, if the developer manually replace the element using `a[3] = 8` it would already result in an optimised solution._

