### PR TITLE
Proposal: Allowed passing of animation param to perform custom reload of items

### DIFF
--- a/TableViewKit/ObservableArray.swift
+++ b/TableViewKit/ObservableArray.swift
@@ -17,7 +17,7 @@ public class ObservableArray<T>: RandomAccessCollection, ExpressibleByArrayLiter
 
     var array: [T]
 
-    var callback: ((ArrayChanges<T>) -> Void)?
+    var callback: ((ArrayChanges<T>, UITableView.RowAnimation?) -> Void)?
 
     /// Creates an empty `ObservableArray`
     public required init() {
@@ -183,11 +183,11 @@ public class ObservableArray<T>: RandomAccessCollection, ExpressibleByArrayLiter
     }
 
     private func notifyChanges(with diff: Diff<T>) {
-        callback?(.beginUpdates(from: diff.fromElements, to: diff.toElements))
-        if !diff.moves.isEmpty { callback?(.moves(diff.moves)) }
-        if !diff.deletes.isEmpty { callback?(.deletes(diff.deletes, diff.deletesElement)) }
-        if !diff.inserts.isEmpty { callback?(.inserts(diff.inserts, diff.insertsElement)) }
-        callback?(.endUpdates(from: diff.fromElements, to: diff.toElements))
+        callback?(.beginUpdates(from: diff.fromElements, to: diff.toElements), nil)
+        if !diff.moves.isEmpty { callback?(.moves(diff.moves), nil) }
+        if !diff.deletes.isEmpty { callback?(.deletes(diff.deletes, diff.deletesElement), nil) }
+        if !diff.inserts.isEmpty { callback?(.inserts(diff.inserts, diff.insertsElement), nil) }
+        callback?(.endUpdates(from: diff.fromElements, to: diff.toElements), nil)
     }
 
 }

--- a/TableViewKit/Protocols/TableItem.swift
+++ b/TableViewKit/Protocols/TableItem.swift
@@ -89,7 +89,7 @@ extension TableItem {
     public func reload(with animation: UITableView.RowAnimation = .automatic) {
         guard let indexPath = indexPath else { return }
         let section = manager?.sections[indexPath.section]
-        section?.items.callback?(.updates([indexPath.row]))
+        section?.items.callback?(.updates([indexPath.row]), animation)
     }
 
     /// Redraw the associated `cell` of the `item` without reloading it

--- a/TableViewKit/TableSection.swift
+++ b/TableViewKit/TableSection.swift
@@ -102,9 +102,9 @@ extension TableSection {
     private func setup(in manager: TableViewManager) {
         self.manager = manager
 
-        items.callback = { [weak self] changes in
+        items.callback = { [weak self] changes, animation in
             if let manager = self?.manager, let sectionIndex = self?.index {
-                manager.onItemsUpdate(with: changes, forSectionIndex: sectionIndex)
+                manager.onItemsUpdate(with: changes, forSectionIndex: sectionIndex, animation: animation)
             }
         }
     }

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -39,10 +39,13 @@ open class TableViewManager {
 
     private func setupSections() {
         sections.forEach { $0.register(in: self) }
-        sections.callback = { [weak self] in self?.onSectionsUpdate(with: $0) }
+        sections.callback = { [weak self] section, animation in
+            self?.onSectionsUpdate(with: section, animation: animation)
+        }
     }
 
-    func onSectionsUpdate(with changes: ArrayChanges<TableSection>) {
+    func onSectionsUpdate(with changes: ArrayChanges<TableSection>, animation: UITableView.RowAnimation? = nil) {
+        let animation = animation ?? self.animation
         switch changes {
         case .inserts(let indexes, let insertedSections):
             insertedSections.forEach { $0.register(in: self) }
@@ -71,8 +74,8 @@ open class TableViewManager {
         }
     }
 
-    func onItemsUpdate(with changes: ArrayChanges<TableItem>, forSectionIndex sectionIndex: Int) {
-
+    func onItemsUpdate(with changes: ArrayChanges<TableItem>, forSectionIndex sectionIndex: Int, animation: UITableView.RowAnimation? = nil) {
+        let animation = animation ?? self.animation
         switch changes {
         case .inserts(let array, let insertedItems):
             insertedItems.forEach { register(type(of: $0).drawer.type) }


### PR DESCRIPTION
This is my proposal to fix the problem of the animation param being ignored on item reloads. What I did is just to propagate the animation value inwards as it was just not being used by the reload methods.