### PR TITLE
Centralise Z positioning logic of cells

### DIFF
--- a/TableViewKit.xcodeproj/project.pbxproj
+++ b/TableViewKit.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		25837C781D87F819001EF4B8 /* ItemCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25837C771D87F819001EF4B8 /* ItemCompatible.swift */; };
 		25B0B7541DC74F6C00591467 /* Editable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B0B7531DC74F6C00591467 /* Editable.swift */; };
 		34A206811FC33340009A7ED3 /* TableViewManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34A206801FC33340009A7ED3 /* TableViewManagerTests.swift */; };
+		76F8AD97292F6937004A8DF2 /* TableViewManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F8AD96292F6937004A8DF2 /* TableViewManagerMock.swift */; };
 		CC09F8891EA79178006FF4EA /* TableViewKitDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC09F8881EA79178006FF4EA /* TableViewKitDataSource.swift */; };
 		CC09F88B1EA791B7006FF4EA /* TableViewKitDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC09F88A1EA791B7006FF4EA /* TableViewKitDelegate.swift */; };
 		CC0DE2C81DE33B9C00E2EDE5 /* AnyEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DE2C71DE33B9C00E2EDE5 /* AnyEquatable.swift */; };
@@ -62,6 +63,7 @@
 		25B0B7531DC74F6C00591467 /* Editable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Editable.swift; path = Protocols/Editable.swift; sourceTree = "<group>"; };
 		34A206801FC33340009A7ED3 /* TableViewManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewManagerTests.swift; sourceTree = "<group>"; };
 		4BCAD51C1D89A704002F3420 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "External/Nimble/build/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
+		76F8AD96292F6937004A8DF2 /* TableViewManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewManagerMock.swift; sourceTree = "<group>"; };
 		CC09F8881EA79178006FF4EA /* TableViewKitDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewKitDataSource.swift; sourceTree = "<group>"; };
 		CC09F88A1EA791B7006FF4EA /* TableViewKitDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewKitDelegate.swift; sourceTree = "<group>"; };
 		CC0DE2C71DE33B9C00E2EDE5 /* AnyEquatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnyEquatable.swift; path = Protocols/AnyEquatable.swift; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 				CC12F72A1F2611BE00F20671 /* ArrayChangesUtils.swift */,
 				CCBE456B1D72F69500414A64 /* TableViewKitTests.swift */,
 				34A206801FC33340009A7ED3 /* TableViewManagerTests.swift */,
+				76F8AD96292F6937004A8DF2 /* TableViewManagerMock.swift */,
 				2519E1CC1E015A0A0021E06E /* ObservableArrayTests.swift */,
 				CCBE456D1D72F69500414A64 /* Info.plist */,
 				2564E6191D88419B00A9DC3E /* TestRegisterNibCell.xib */,
@@ -280,6 +283,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = CCBE45521D72F69400414A64;
@@ -368,6 +372,7 @@
 				2519E1CD1E015A0A0021E06E /* ObservableArrayTests.swift in Sources */,
 				CC9D50E11D8496180010FCA3 /* TableViewDelegateTests.swift in Sources */,
 				CCE400F61D731B7300537715 /* TableViewDataSourceTests.swift in Sources */,
+				76F8AD97292F6937004A8DF2 /* TableViewManagerMock.swift in Sources */,
 				CCBE456C1D72F69500414A64 /* TableViewKitTests.swift in Sources */,
 				34A206811FC33340009A7ED3 /* TableViewManagerTests.swift in Sources */,
 			);

--- a/TableViewKit/Protocols/CellDrawer.swift
+++ b/TableViewKit/Protocols/CellDrawer.swift
@@ -40,6 +40,10 @@ public extension CellDrawer {
         if let cell = cell as? ItemCompatible {
             cell.item = item as? TableItem
         }
+        
+        if let zPosition = manager.zPositionForCell(at: indexPath) {
+            cell.layer.zPosition = zPosition
+        }
 
         // swiftlint:disable:next force_cast
         return cell as! Cell

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -97,6 +97,9 @@ open class TableViewManager {
         }
     }
 
+    open func zPositionForCell(at indexPath: IndexPath) -> CGFloat? {
+        nil
+    }
 }
 
 extension TableViewManager {

--- a/TableViewKitTests/TableViewManagerMock.swift
+++ b/TableViewKitTests/TableViewManagerMock.swift
@@ -1,0 +1,14 @@
+@testable import TableViewKit
+
+final class TableViewManagerMock: TableViewManager {
+    
+    private(set) var zPositionForCellCallsCount = 0
+    private(set) var zPositionForCellReceivedIndexPath: IndexPath?
+    var zPositionForCellReturnValue: CGFloat?
+    
+    override func zPositionForCell(at indexPath: IndexPath) -> CGFloat? {
+        zPositionForCellCallsCount += 1
+        zPositionForCellReceivedIndexPath = indexPath
+        return zPositionForCellReturnValue
+    }
+}

--- a/TableViewKitTests/TableViewManagerTests.swift
+++ b/TableViewKitTests/TableViewManagerTests.swift
@@ -198,4 +198,18 @@ class TableViewManagerTests: XCTestCase {
 
     }
 
+    func testZPositionForCell() {
+        let zPosition: CGFloat = 4
+        let tableManager = TableViewManagerMock(tableView: UITableView())
+        tableManager.zPositionForCellReturnValue = zPosition
+        manager = tableManager
+
+        let sections = Array(
+            repeating: HeaderFooterTitleSection(items: .init(repeating: TestItem(), count: 3)),
+            count: 2
+        )
+
+        let cells = manager.sections.flatMap { $0.items }.flatMap { $0.cell }
+        cells.forEach { XCTAssertEqual($0.layer.zPosition, zPosition) }
+    }
 }

--- a/TableViewKitTests/TableViewManagerTests.swift
+++ b/TableViewKitTests/TableViewManagerTests.swift
@@ -198,18 +198,19 @@ class TableViewManagerTests: XCTestCase {
 
     }
 
-    func testZPositionForCell() {
+    func testZPositionForCell() throws {
         let zPosition: CGFloat = 4
-        let tableManager = TableViewManagerMock(tableView: UITableView())
-        tableManager.zPositionForCellReturnValue = zPosition
-        manager = tableManager
-
         let sections = Array(
             repeating: HeaderFooterTitleSection(items: .init(repeating: TestItem(), count: 3)),
             count: 2
         )
-
-        let cells = manager.sections.flatMap { $0.items }.flatMap { $0.cell }
-        cells.forEach { XCTAssertEqual($0.layer.zPosition, zPosition) }
+        let tableManager = TableViewManagerMock(tableView: UITableView(), sections: sections)
+        tableManager.zPositionForCellReturnValue = zPosition
+        let dataSource = try XCTUnwrap(tableManager.dataSource)
+        
+        let cell = dataSource.tableView(tableManager.tableView, cellForRowAt: .init(row: 1, section: 1))
+        
+        XCTAssertEqual(tableManager.zPositionForCellCallsCount, 1)
+        XCTAssertEqual(cell.layer.zPosition, zPosition)
     }
 }


### PR DESCRIPTION
We want to control the `zPosition` of each cell in the table based in their `indexPath`.

Although this could be achieved by setting the `zPosition` individually in each cell `draw` method, this would implicate in a lot of code duplications and could also lead to unpredictable behaviours in case one of the cell drawers is left out.

My proposal is to make `TableManager` the one responsible for setting the `zPosition` of the cells in the whole table. The idea is to have a method in `TableManager` that returns the `zPosition` for the cell at a received `indexPath`. This method would then be invoked by `CellDrawer`, right after the dequeue of the cell is done. By default the method would return `nil`, which in this case would not set the `zPosition`. But once implemented in a `TableManager` subclass, any logic to set the `zPosition` could be applied.

With this approach, we are centralising the Z positioning logic for all the cells in the table in one single source of truth.