### PR TITLE
Centralise Z positioning logic of headers and footers

### DIFF
--- a/TableViewKit/TableViewKitDelegate.swift
+++ b/TableViewKit/TableViewKitDelegate.swift
@@ -48,12 +48,24 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return view(for: { $0.header }, inSection: section)
+        let view = view(for: { $0.header }, inSection: section)
+
+        if let zPosition = manager.zPositionForHeader(in: section) {
+            view?.layer.zPosition = zPosition
+        }
+
+        return view
     }
 
     /// Implementation of UITableViewDelegate
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return view(for: { $0.footer }, inSection: section)
+        let view = view(for: { $0.footer }, inSection: section)
+
+        if let zPosition = manager.zPositionForFooter(in: section) {
+            view?.layer.zPosition = zPosition
+        }
+
+        return views
     }
 
     /// Implementation of UITableViewDelegate

--- a/TableViewKit/TableViewKitDelegate.swift
+++ b/TableViewKit/TableViewKitDelegate.swift
@@ -65,7 +65,7 @@ open class TableViewKitDelegate: NSObject, UITableViewDelegate {
             view?.layer.zPosition = zPosition
         }
 
-        return views
+        return view
     }
 
     /// Implementation of UITableViewDelegate

--- a/TableViewKit/TableViewManager.swift
+++ b/TableViewKit/TableViewManager.swift
@@ -100,6 +100,15 @@ open class TableViewManager {
     open func zPositionForCell(at indexPath: IndexPath) -> CGFloat? {
         nil
     }
+
+    open func zPositionForHeader(in section: Int) -> CGFloat? {
+        nil
+    }
+
+    open func zPositionForFooter(in section: Int) -> CGFloat? {
+        nil
+    }
+
 }
 
 extension TableViewManager {

--- a/TableViewKitTests/TableViewDelegateTests.swift
+++ b/TableViewKitTests/TableViewDelegateTests.swift
@@ -23,6 +23,23 @@ class CustomHeaderFooterView: UITableViewHeaderFooterView {
     }
 }
 
+class TestRegisterHeaderFooterViewItem: HeaderFooter {
+    static var drawer = AnyHeaderFooterDrawer(TestRegisterHeaderFooterDrawer.self)
+    var height: Height? = .static(60)
+}
+
+// MARK: - AncillariesBundleInTheAppHeaderDrawer
+
+class TestRegisterHeaderFooterDrawer: HeaderFooterDrawer {
+    static let bundle = Bundle(for: TestRegisterHeaderFooterViewItem.self)
+    static let nib = UINib(nibName: String(describing: TestRegisterHeaderFooterView.self), bundle: bundle)
+    static var type = HeaderFooterType.nib(TestRegisterHeaderFooterDrawer.nib, TestRegisterHeaderFooterView.self)
+
+    static func draw(_ view: TestRegisterHeaderFooterView, with item: TestRegisterHeaderFooterViewItem) {
+    }
+}
+
+
 class CustomHeaderDrawer: HeaderFooterDrawer {
 
     static public var type = HeaderFooterType.class(CustomHeaderFooterView.self)
@@ -51,6 +68,18 @@ class ViewHeaderFooterSection: TableSection {
 
     internal var header: HeaderFooterView = .view(ViewHeaderFooter(title: "First Section"))
     internal var footer: HeaderFooterView = .view(ViewHeaderFooter(title: "Section Footer\nHola"))
+
+    convenience init(items: [TableItem]) {
+        self.init()
+        self.items.insert(contentsOf: items, at: 0)
+    }
+}
+
+class ViewHeaderFooterSectionInstaciated: TableSection {
+    var items: ObservableArray<TableItem> = []
+
+    internal var header: HeaderFooterView = .view(TestRegisterHeaderFooterViewItem())
+    internal var footer: HeaderFooterView = .view(TestRegisterHeaderFooterViewItem())
 
     convenience init(items: [TableItem]) {
         self.init()
@@ -318,4 +347,5 @@ class TableViewDelegateTests: XCTestCase {
                                     withSender: nil)
         expect(actionableItem.check) == 1
     }
+    
 }

--- a/TableViewKitTests/TableViewManagerMock.swift
+++ b/TableViewKitTests/TableViewManagerMock.swift
@@ -4,11 +4,30 @@ final class TableViewManagerMock: TableViewManager {
     
     private(set) var zPositionForCellCallsCount = 0
     private(set) var zPositionForCellReceivedIndexPath: IndexPath?
+    private(set) var zPositionForHeaderCallsCount = 0
+    private(set) var zPositionForHeaderReceivedSection: Int?
+    private(set) var zPositionForFooterCallsCount = 0
+    private(set) var zPositionForFooterReceivedSection: Int?
     var zPositionForCellReturnValue: CGFloat?
+    var zPositionForHeaderReturnValue: CGFloat?
+    var zPositionForFooterReturnValue: CGFloat?
     
     override func zPositionForCell(at indexPath: IndexPath) -> CGFloat? {
         zPositionForCellCallsCount += 1
         zPositionForCellReceivedIndexPath = indexPath
         return zPositionForCellReturnValue
     }
+
+    override func zPositionForHeader(in section: Int) -> CGFloat? {
+        zPositionForHeaderCallsCount += 1
+        zPositionForHeaderReceivedSection = section
+        return zPositionForHeaderReturnValue
+    }
+
+    override func zPositionForFooter(in section: Int) -> CGFloat? {
+        zPositionForFooterCallsCount += 1
+        zPositionForFooterReceivedSection = section
+        return zPositionForFooterReturnValue
+    }
+
 }

--- a/TableViewKitTests/TableViewManagerTests.swift
+++ b/TableViewKitTests/TableViewManagerTests.swift
@@ -213,4 +213,42 @@ class TableViewManagerTests: XCTestCase {
         XCTAssertEqual(tableManager.zPositionForCellCallsCount, 1)
         XCTAssertEqual(cell.layer.zPosition, zPosition)
     }
+
+    func testZPositionForHeader() throws {
+        // Given
+        let zPosition: CGFloat = 4
+        let tableManager = tableManagerForInstanciatedSections(itemsBySection: 3, numberOfSections: 2)
+        tableManager.zPositionForHeaderReturnValue = zPosition
+        let delegate = try XCTUnwrap(tableManager.delegate)
+        // When
+        let headerSection0 = try XCTUnwrap(delegate.tableView(tableManager.tableView, viewForHeaderInSection: 0))
+        let headerSection1 = try XCTUnwrap(delegate.tableView(tableManager.tableView, viewForHeaderInSection: 1))
+        // Then
+        XCTAssertEqual(tableManager.zPositionForHeaderCallsCount, 2)
+        XCTAssertEqual(headerSection0.layer.zPosition, zPosition)
+        XCTAssertEqual(headerSection1.layer.zPosition, zPosition)
+    }
+
+    func testZPositionForFooter() throws {
+        // Given
+        let zPosition: CGFloat = 4
+        let tableManager = tableManagerForInstanciatedSections(itemsBySection: 3, numberOfSections: 2)
+        tableManager.zPositionForFooterReturnValue = zPosition
+        let delegate = try XCTUnwrap(tableManager.delegate)
+        // When
+        let footerSection0 = try XCTUnwrap(delegate.tableView(tableManager.tableView, viewForFooterInSection: 0))
+        let footerSection1 = try XCTUnwrap(delegate.tableView(tableManager.tableView, viewForFooterInSection: 1))
+        // Then
+        XCTAssertEqual(tableManager.zPositionForFooterCallsCount, 2)
+        XCTAssertEqual(footerSection0.layer.zPosition, zPosition)
+        XCTAssertEqual(footerSection1.layer.zPosition, zPosition)
+    }
+
+    private func tableManagerForInstanciatedSections(itemsBySection: Int, numberOfSections: Int) -> TableViewManagerMock {
+        let sections = Array(
+            repeating: ViewHeaderFooterSectionInstaciated(items: .init(repeating: TestItem(), count: itemsBySection)),
+            count: numberOfSections
+        )
+        return TableViewManagerMock(tableView: UITableView(), sections: sections)
+    }
 }


### PR DESCRIPTION
We want to control the `zPosition` of each `header/footer` in the table based in their section.

My proposal is to make `TableManager` the one responsible for setting the `zPosition` of the section headers and footers in the whole table. The idea is to have a method in `TableManager` that returns the `zPosition` for the header at a received section or the footer at received section. This method would then be invoked by `TableViewKitDelegate`, right after the `HeaderFooterDrawer` instantiation of the header/footer is done. By default the method would return nil, which in this case would not set the zPosition. But once implemented in a `TableManager` subclass, any logic to set the zPosition could be applied.

Noticing that we have 2 separated methods one for section headers

`open func zPositionForHeader(in section: Int) -> CGFloat?`

and another for section footers

`open func zPositionForFooter(in section: Int) -> CGFloat?`

With this approach, we are centralising the Z positioning logic for all the sections headers and footers in the table in one single source of truth.